### PR TITLE
Added support for `--version` flag

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ Build
 Build.bat
 .idea
 *.iml
+*.sw[op]

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ Build.bat
 .idea
 *.iml
 *.sw[op]
+.DS_Store

--- a/CHANGES
+++ b/CHANGES
@@ -60,6 +60,8 @@ Revision history
         - When job fails, we now move on to the next job in the config
           (previously the entire config would be skipped)
 
+        - Added version information to the CLI via the `--version` flag (#38)
+
 1.1     April 20, 2016
 
         - On OS X, expand `~` to the actual `$HOME` path in SQLite DB connection string (#1)

--- a/doc/html/serge.html
+++ b/doc/html/serge.html
@@ -24,7 +24,7 @@
 
 <h1 id="SYNOPSIS">SYNOPSIS</h1>
 
-<p><code>serge &lt;command&gt; [command-specific-parameters] [--command-specific-options] [--debug]</code></p>
+<p><code>serge [--version] &lt;command&gt; [command-specific-parameters] [--command-specific-options] [--debug]</code></p>
 
 <p>Run <code>serge help &lt;command&gt;</code> for help on a particular command.</p>
 
@@ -52,6 +52,12 @@
 
 <dl>
 
+<dt><b>--version</b></dt>
+<dd>
+
+<p>Print Serge version information and exit.</p>
+
+</dd>
 <dt><b>--dry-run</b></dt>
 <dd>
 

--- a/doc/pod/serge.pod
+++ b/doc/pod/serge.pod
@@ -40,6 +40,10 @@ replacing original strings with translated ones.
 
 =over 8
 
+=item B<--version>
+
+Print Serge version information and exit.
+
 =item B<--dry-run>
 
 Just report and validate configuration files, but do no actual

--- a/lib/Serge/Application.pm
+++ b/lib/Serge/Application.pm
@@ -8,6 +8,7 @@ use File::Find qw(find);
 use File::Spec::Functions qw(rel2abs catfile);
 use Getopt::Long qw(:config no_auto_abbrev no_ignore_case pass_through);
 use Serge::Config::Collector;
+use Serge;
 
 sub new {
     my ($class) = @_;
@@ -24,11 +25,20 @@ sub new {
 sub run {
     my ($self) = @_;
 
-    my ($help, $debug);
+    my ($help, $debug, $version);
     my $result = GetOptions(
         'help' => \$help,
         'debug' => \$debug,
+        'version' => \$version,
     );
+
+    my $command = shift @ARGV;
+
+    # print out version when passing the flag to a bare `serge` command
+    if ($version && $command eq '') {
+        print "Serge $Serge::VERSION\n";
+        exit(0);
+    }
 
     if (!$result) {
         $self->error("Failed to parse some command-line parameters.");
@@ -46,8 +56,6 @@ sub run {
     unshift @ARGV, 'help' if $help;
 
     $self->load_command_plugins;
-
-    my $command = shift @ARGV;
 
     my $handler = $self->{commands}->{$command};
     if (!$handler) {

--- a/lib/Serge/Application.pm
+++ b/lib/Serge/Application.pm
@@ -6,7 +6,7 @@ use Cwd;
 use File::Basename;
 use File::Find qw(find);
 use File::Spec::Functions qw(rel2abs catfile);
-use Getopt::Long qw(:config pass_through);
+use Getopt::Long qw(:config no_auto_abbrev no_ignore_case pass_through);
 use Serge::Config::Collector;
 
 sub new {


### PR DESCRIPTION
In this PR support for `--version|-V` flags is added, which prints out the current serge version.

Likewise, the default options for `Getopt::Long` have been adjusted to be more POSIX-friendly and intuitive, by making it case-sensitive and disabling auto abbreviation (this way only `--version` and `-V` are considered).