### PR TITLE
Use require_ok in compile.t for more useful output on failures.

### DIFF
--- a/t/compile.t
+++ b/t/compile.t
@@ -18,11 +18,8 @@ map {
     }, catfile($thisdir, $_));
 } qw(../bin ../lib);
 
-for (@tests) {
-    my $output = `perl -I "$libpath" -c $_ 2>&1`;
-    my $ok = ($? >> 8 == 0);
-    print $output unless $ok;
-    ok($ok, "$_ syntax check");
+foreach my $file (@tests) {
+    require_ok $file;
 }
 
 done_testing();


### PR DESCRIPTION
Output is a bit nicer and there is no need to turn on verbose=1 to see syntax errors.
```
t/compile.t .. 7/?
#   Failed test 'require '/home/user/tpratt/work/serge/serge/t/../lib/Serge/Engine/Plugin/parse_csv.pm';'
#   at t/compile.t line 22.
#     Tried to require ''/home/user/tpratt/work/serge/serge/t/../lib/Serge/Engine/Plugin/parse_csv.pm''.
#     Error:  Global symbol "%col_for" requires explicit package name at /home/user/tpratt/work/serge/serge/t/../lib/Serge/Engine/Plugin/parse_csv.pm line 164.
# Compilation failed in require at (eval 83) line 2.
# Looks like you failed 1 test of 87.
t/compile.t .. Dubious, test returned 1 (wstat 256, 0x100)
Failed 1/87 subtests

```