### PR TITLE
Make broken tests easier to debug

### DIFF
--- a/Build.PL
+++ b/Build.PL
@@ -15,6 +15,7 @@ my $builder = Module::Build->new(
     build_requires           => {
         'Test::More'         => '0.94',
         'File::Copy::Recursive' => 0,
+        'Test::Files'        => 0,
     },
     requires => {
         'Authen::SASL'       => 0,

--- a/t/lib/Test/Diff.pm
+++ b/t/lib/Test/Diff.pm
@@ -9,39 +9,10 @@ require Exporter;
 @ISA = qw(Exporter);
 @EXPORT = qw(files_diff dir_diff);
 
-use Digest::MD5;
 use File::Find qw/find/;
-use File::Spec::Functions qw/abs2rel catfile/;
+use File::Spec::Functions qw/abs2rel/;
 use Test::More;
-
-sub file_md5 {
-    my $filepath = shift;
-    return undef unless -f $filepath;
-
-    my $md5 = Digest::MD5->new;
-
-    open my $f, $filepath;
-    binmode $f;
-    $md5->addfile($f);
-    close $f;
-
-    return $md5->digest;
-}
-
-sub files_diff {
-    my ($f1, $f2, $opt) = @_;
-
-    my $base = defined($opt) && exists($opt->{base_dir}) ? $opt->{base_dir} : undef;
-
-    my ($fr1, $fr2) = map { $base ? abs2rel($_, $base) : $_} ($f1, $f2);
-
-    my $ok = 1;
-
-    $ok &= fail "File '$f1' should exist" unless -f $f1;
-    $ok &= fail "File '$f2' should exist" unless -f $f2;
-
-    ok(file_md5($f1) eq file_md5($f2), "Files '$fr1' and '$fr2' should be equal") if $ok;
-}
+use Test::Files;
 
 sub dir_diff {
     my ($d1, $d2, $opt) = @_;
@@ -56,16 +27,7 @@ sub dir_diff {
     fail "Directory '$dr1' exists but '$dr2' doesn't" if -d $dr1 && !-d $dr2;
     fail "Directory '$dr1' doesn't exist but '$dr2' does" if !-d $dr1 && -d $dr2;
 
-    my $msg = "Compare directory '$dr1' with '$dr2'";
-
-    return subtest $msg => sub {
-        find(sub {
-            my $t1 = $File::Find::name;
-            my $t2 = catfile($d2, abs2rel($t1, $d1));
-
-            files_diff($t1, $t2, { base_dir => $base }) if (-f $t1);
-        }, $d1);
-    };
+    compare_dirs_ok $dr1, $dr2, "The files in '$dr1' are the same as the files in '$dr2'.";
 }
 
 1;


### PR DESCRIPTION
I'm writing my first plugin for Serge and I made a few tweaks to make the test output more useful.

<strike>
# Changes to t/compile.t

Output is a bit nicer and there is no need to turn on verbose=1 to see syntax errors.
```
t/compile.t .. 7/?
#   Failed test 'require '/home/user/tpratt/work/serge/serge/t/../lib/Serge/Engine/Plugin/parse_csv.pm';'
#   at t/compile.t line 22.
#     Tried to require ''/home/user/tpratt/work/serge/serge/t/../lib/Serge/Engine/Plugin/parse_csv.pm''.
#     Error:  Global symbol "%col_for" requires explicit package name at /home/user/tpratt/work/serge/serge/t/../lib/Serge/Engine/Plugin/parse_csv.pm line 164.
# Compilation failed in require at (eval 83) line 2.
# Looks like you failed 1 test of 87.
t/compile.t .. Dubious, test returned 1 (wstat 256, 0x100)
Failed 1/87 subtests

```
</strike>

I removed the above change from the PR.  See comments.

# Changes to t/engine.t

Use Test::Files to diff files and print diff output to console.  I'm writing a new parser plugin and it's a pain to run the test, diff all the files, update my code and test data, and repeat.  I'm not sure how conservative you are with bringing in external dependencies, but I think the improvement is worth it.

New output:

```
t/engine.t ... 42/? jjjj
    #   Failed test 'The files in 'test-output/database' are the same as the files in 'reference-output/database'.'
    #   at /home/user/tpratt/work/fds-serge/serge/t/lib/Test/Diff.pm line 30.
    # +---+----------------------------+---+---------------------------------+
    # |   |test-output/database/items  |   |reference-output/database/items  |
    # | Ln|                            | Ln|                                 |
    # +---+----------------------------+---+---------------------------------+
    # |  1|items                       |  1|items                            |
    # |  2|{                           |  2|{                                |
    # |   |                            *  3|    0    1 3 1 1 string1 NO 0    *
    # |   |                            *  4|    1    2 5 1 2 string2 NO 0    *
    # |   |                            *  5|    2    3 7 1 3 string3 NO 0    *
    # |   |                            *  6|    3    4 9 1 4 string4 NO 0    *
    # |  3|}                           |  7|}                                |
    # +---+----------------------------+---+---------------------------------+
    # +---+------------------------------+---+-----------------------------------+
    # |   |test-output/database/strings  |   |reference-output/database/strings  |
    # | Ln|                              | Ln|                                   |
    # +---+------------------------------+---+-----------------------------------+
    # |  1|strings                       |  1|strings                            |
    # |  2|{                             |  2|{                                  |
    # |   |                              *  3|    0    1 2 `Value 1` NO 0        *
    # |   |                              *  4|    1    2 4 `"Value 2"` NO 0      *
    # |   |                              *  5|    2    3 6 '' NO 0               *
    # |   |                              *  6|    3    4 8 []{}() NO 0           *
    # |  3|}                             |  7|}                                  |
    # +---+------------------------------+---+-----------------------------------+
    # +---+-----------------------------------+---+--------------------------------------------------------------------------------+
    # |   |test-output/database/translations  |   |reference-output/database/translations                                          |
    # | Ln|                                   | Ln|                                                                                |
    # +---+-----------------------------------+---+--------------------------------------------------------------------------------+
    # |  1|translations                       |  1|translations                                                                    |
    # |  2|{                                  |  2|{                                                                               |
    # |   |                                   *  3|    0    1 10 1 test `\xe1\xb9\xbc\xc3\xa1\xc4\xbc\xc5\xa9\xc4\x93 1` NO 0 0    *
    # |   |                                   *  4|    1    2 11 2 test `"\xe1\xb9\xbc\xc3\xa1\xc4\xbc\xc5\xa9\xc4\x93 2"` NO 0 0  *
    # |   |                                   *  5|    2    3 12 3 test '' NO 0 0                                                  *
    # |   |                                   *  6|    3    4 13 4 test []{}() NO 0 0                                              *
    # |  3|}                                  |  7|}                                                                               |
    # +---+-----------------------------------+---+--------------------------------------------------------------------------------+
    # +---+----------------------------------------------------------+---+----------------------------------------------------------------------+
    # |   |test-output/database/properties                           |   |reference-output/database/properties                                  |
    # | Ln|                                                          | Ln|                                                                      |
    # +---+----------------------------------------------------------+---+----------------------------------------------------------------------+
    # |  1|properties                                                |  1|properties                                                            |
    # |  2|{                                                         |  2|{                                                                     |
    # *  3|    0    1 job-hash:test_namespace:test_job               *  3|    0     1 source:1 35400722582cfb84aa599d37fa8f9f97                 *
    # *  4|         3f0288708c15c7ce85e4623aa3bdc60f                 *  4|    1     2 hash:1 35400722582cfb84aa599d37fa8f9f97                   *
    # *  5|    1    2 job-plugin:test_namespace:test_job parse_csv.  *  5|    2     3 size:1 121                                                *
    # *  6|    2    3 job-serializer-plugin:test_namespace:test_job  *  6|    3     4 items:1 1,2,3,4                                           *
    # *  7|         serialize_po.                                    *  7|    4     5 ts:1:test:count 4                                         *
    # *  8|    3    4 job-engine:test_namespace:test_job 1.2         *  8|    5     6 usn:1:test 13                                             *
    # |   |                                                          *  9|    6     7 ts:1:test 02666fcd243f78d9e2f89d31c6679b1c                *
    # |   |                                                          * 10|    7     8 target:1:test_job:test d55c993d5242c39d25aae1faf9594b3b   *
    # |   |                                                          * 11|    8     9 target:mtime:1:test_job:test 12345678                     *
    # |   |                                                          * 12|    9     10 source:1:test_job:test 35400722582cfb84aa599d37fa8f9f97  *
    # |   |                                                          * 13|    10    11 source:ts:1:test_job:test                                *
    # |   |                                                          * 14|          02666fcd243f78d9e2f89d31c6679b1c                            *
    # |   |                                                          * 15|    11    12 job-hash:test_namespace:test_job                         *
    # |   |                                                          * 16|          7d223b6524e144f7d44098881b087751                            *
    # |   |                                                          * 17|    12    13 job-plugin:test_namespace:test_job parse_json_keyvalue.  *
    # |   |                                                          * 18|    13    14 job-serializer-plugin:test_namespace:test_job            *
    # |   |                                                          * 19|          serialize_po.                                               *
    # |   |                                                          * 20|    14    15 job-engine:test_namespace:test_job 1.2                   *
    # |  9|}                                                         | 21|}                                                                     |
    # +---+----------------------------------------------------------+---+----------------------------------------------------------------------+

    #   Failed test 'Directory 'test-output/po' doesn't exist but 'reference-output/po' does'
    #   at /home/user/tpratt/work/fds-serge/serge/t/lib/Test/Diff.pm line 28.

    #   Failed test 'The files in 'test-output/po' are the same as the files in 'reference-output/po'.'
    #   at /home/user/tpratt/work/fds-serge/serge/t/lib/Test/Diff.pm line 30.
    # test-output/po is not a valid directory
    # Looks like you failed 3 tests of 5.

#   Failed test 'Test config: /home/user/tpratt/work/fds-serge/serge/t/data/engine/parse_csv/00/translate.serge'
#   at t/engine.t line 156.
t/engine.t ... 56/? # Looks like you failed 1 test of 57.
```
