### PR TITLE
New parse_csv plugin

### DIFF
--- a/Build.PL
+++ b/Build.PL
@@ -13,9 +13,10 @@ my $builder = Module::Build->new(
         'Module::Build'      => 0,
     },
     build_requires           => {
-        'Test::More'         => '0.94',
-        'Text::Diff'         => 0,
         'File::Copy::Recursive' => 0,
+        'Test::More'         => '0.94',
+        'Text::CSV_XS'       => 0,
+        'Text::Diff'         => 0,
     },
     requires => {
         'Authen::SASL'       => 0,
@@ -29,6 +30,9 @@ my $builder = Module::Build->new(
         'XML::Parser::Style::IxTree' => 0,
         'XML::Twig'          => 0,
         'YAML::XS'           => 0,
+    },
+    recommends => {
+        'Text::CSV_XS'       => 0,
     },
     add_to_cleanup           => ['Serge-*', 'Makefile.PL', 'MYMETA.*', 'META.*', 'MANIFEST.bak', 'MANIFEST'],
     create_makefile_pl       => 'traditional',

--- a/lib/Serge/Engine/Plugin/parse_csv.pm
+++ b/lib/Serge/Engine/Plugin/parse_csv.pm
@@ -1,0 +1,277 @@
+package Serge::Engine::Plugin::parse_csv;
+
+use 5.10.0;
+use strict;
+use warnings;
+
+use parent 'Serge::Engine::Plugin::Base::Parser';
+
+use English qw( -no_match_vars );
+use Data::Dumper;
+use IO::String;
+use Serge::Mail;
+use Serge::Util qw(xml_escape_strref);
+
+sub name {
+    return 'CSV Parser Plugin';
+}
+
+sub init {
+    my $self = shift;
+
+    $self->SUPER::init(@_);
+
+    $self->merge_schema({
+        email_from    => 'STRING',
+        email_to      => 'ARRAY',
+        email_subject => 'STRING',
+
+        end_of_line    => 'STRING',
+        delimiter      => 'STRING',
+        escape         => 'STRING',
+        quote          => 'STRING',
+
+        column_key     => 'STRING',
+        column_string  => 'STRING',
+        column_context => 'STRING',
+        column_comment => 'STRING',
+    });
+
+    $self->add('after_job', \&report_errors);
+}
+
+sub validate_data {
+    my $self = shift;
+
+    $self->SUPER::validate_data;
+
+    eval('use Text::CSV_XS;');
+    die "ERROR: To use parse_csv parser, please install Text::CSV_XS module (run 'cpan Text::CSV_XS')\n" if $@;
+}
+
+sub quoted_list_str {
+    my ($items) = @_;
+    if ($items && @$items > 0) {
+        return q{'} . join(q{', '}, @$items) . q{'};
+    }
+    return '';
+}
+
+sub parse {
+    my ($self, $textref, $callbackref, $lang) = @_;
+    my $has_errors = 0;
+
+    eval('use Text::CSV_XS;');
+    die $@ if $@;
+
+    die 'callbackref not specified' unless $callbackref;
+
+    my $sep_char           = $self->{data}->{delimiter}         // q{,};
+    my $eol                = $self->{data}->{end_of_line}       // $INPUT_RECORD_SEPARATOR;
+    my $escape_char        = $self->{data}->{escape}            // q{"};
+    my $quote_char         = $self->{data}->{quote}             // q{"};
+
+    my $key_col_name       = lc($self->{data}->{column_key}     // 'Key');
+    my $text_col_name      = lc($self->{data}->{column_string}  // 'String');
+    my $context_col_name   = lc($self->{data}->{column_context} // $key_col_name);
+    my $comment_col_name   = lc($self->{data}->{column_comment} // 'Comment');
+
+    my $csv_fh = IO::String->new($textref);
+    my $csv = Text::CSV_XS->new({
+        allow_loose_quotes => 1,
+        binary             => 1,
+        eol                => $eol,
+        escape_char        => $escape_char,
+        quote_char         => $quote_char,
+        sep_char           => $sep_char,
+    });
+
+    my @out_lines;
+
+    my @headers;
+    my $header_line;
+    # Construct hashref of { col_name => position }
+    my $col_for = do {
+        my $tokens = $csv->getline($csv_fh);
+        die "Could not parse the header" if $self->_push_csv_error_and_print($csv);
+
+        my %col_for;
+        for(my $i = 0; $i < @$tokens; $i++) {
+            $col_for{lc $tokens->[$i]} = $i;
+        }
+
+        @headers = @$tokens;
+        $csv->combine(@$tokens) or $self->_push_csv_error_and_print($csv);
+        $header_line = $csv->string;
+        die "Could not parse the header" if $self->_push_csv_error_and_print($csv);
+        push @out_lines, $header_line;
+        \%col_for;
+    };
+
+    my $key_col_idx = $col_for->{$key_col_name};
+    if (!defined($key_col_idx)) {
+        $self->_push_error_and_die(
+            "Couldn't find required field '$key_col_name' in CSV headers " .
+            quoted_list_str([(keys %$col_for)]));
+    }
+    my $text_col_idx = $col_for->{$text_col_name};
+    if (!defined($text_col_idx)) {
+        $self->_push_error_and_die(
+            "Couldn't find required field '$text_col_name' in CSV headers " .
+            quoted_list_str([(keys %$col_for)]));
+    }
+    my $context_col_idx = exists $col_for->{$context_col_name} ? $col_for->{$context_col_name} : -1;
+    my $comment_col_idx = exists $col_for->{$comment_col_name} ? $col_for->{$comment_col_name} : -1;
+
+    # When possible, we continue parsing on errors. We still die at the end,
+    # but this way we'll show the user all errors in the CSV file in one go,
+    # not just the first we encounter.
+    LINE:
+    while(my $tokens = $csv->getline($csv_fh)) {
+        $has_errors++ && next LINE if $self->_push_csv_error_and_print($csv);
+
+        if (@$tokens != @headers) {
+            my $line_num = $csv_fh->input_line_number;
+            my $num_tokens = @$tokens;
+            my $num_headers = @headers;
+            $self->_push_error_and_print(
+                "Can't parse line $line_num\n" .
+                "\tError:    The file has $num_headers header fields, but we found $num_tokens tokens at line $line_num\n" .
+                "\tHeaders:  " . join('|', @headers) . "\n" .
+                "\tContent:  " . join('|', @$tokens));
+            $has_errors = 1;
+            next LINE;
+        }
+
+        my ($key, $text) = @$tokens[$key_col_idx, $text_col_idx];
+        my $context = $context_col_idx >= 0 ? $tokens->[$context_col_idx] : undef;
+        my $comment = $comment_col_idx >= 0 ? $tokens->[$comment_col_idx] : undef;
+
+        if (!$lang || $self->{import_mode}) {
+            &$callbackref($text, $context, $comment, undef, $lang, $key);
+        } else {
+            $tokens->[$text_col_idx] = &$callbackref($text, $context, $comment, undef, $lang, $key);
+            my $status = $csv->combine(@$tokens);
+            $has_errors++ && next LINE if $self->_push_csv_error_and_print($csv);
+            push @out_lines, $csv->string;
+        }
+    }
+
+    if (!$csv->eof) {
+        $has_errors++ if $self->_push_csv_error_and_print($csv);
+    }
+
+    if ($has_errors) {
+        # The errors will be printed or mailed. This isn't the place to display them.
+        die "Encountered errors. Cannot continue";
+    }
+
+    if (!$lang || $self->{import_mode}) {
+        return $$textref;
+    } else {
+        # $csv->combine() adds end-of-line characters so don't join on
+        # newline here.
+        return join('', @out_lines);
+    }
+}
+
+sub report_errors {
+    my ($self, $phase) = @_;
+
+    my $email_from = $self->{data}->{email_from};
+    if (!$email_from) {
+        $self->{_csv_errors} = {};
+        return;
+    }
+
+    my $email_to = $self->{data}->{email_to};
+    if (!$email_to) {
+        $self->{_csv_errors} = {};
+        return;
+    }
+
+    my $email_subject = $self->{data}->{email_subject}
+        || "[$self->{parent}->{id}]: Serge CSV Parse Errors";
+
+    my $text;
+    foreach my $key (sort keys %{$self->{_csv_errors}}) {
+        $text .= "<hr />\n<p><b style='color: red'>$key</b>\n";
+        my $messages = $self->{_csv_errors}->{$key};
+        foreach my $message (@$messages) {
+            xml_escape_strref(\$message);
+            $text .= "<pre>$message</pre></p>\n";
+        }
+    }
+
+    $self->{_csv_errors} = {};
+
+    if ($text) {
+        $text = qq|
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+</head>
+<body style="font-family: sans-serif; font-size: 120%">
+
+<p>
+
+The following parsing errors were found when attempting to localize CSV files.
+</p>
+
+$text
+
+</body>
+</html>
+|;
+
+        Serge::Mail::send_html_message(
+            $email_from,
+            $email_to,
+            $email_subject,
+            $text
+        );
+    }
+
+    return;
+}
+
+sub _push_error {
+    my ($self, $message) = @_;
+    push @{$self->{_csv_errors}->{$self->_mail_key}}, $message;
+    return;
+}
+
+sub _push_error_and_print {
+    my ($self, $message) = @_;
+    $self->_push_error($message);
+    print "Error: ${\$self->_mail_key}: $message\n";
+    return;
+}
+
+sub _push_csv_error_and_print {
+    my ($self, $csv) = @_;
+
+    if (my $error = $csv->error_diag) {
+        my (undef, undef, $bad_part) = $csv->error_diag;
+        my $formatted_error = "Error at line $INPUT_LINE_NUMBER:\n" .
+            "\tError:   " . $csv->error_diag . "\n" .
+            "\tContent: " . $csv->error_input;
+        $self->_push_error_and_print($formatted_error);
+        return 1;
+    }
+
+    return 0;
+}
+
+sub _push_error_and_die {
+    my ($self, $message) = @_;
+    $self->_push_error($message);
+    die "Error: ${\$self->_mail_key}: $message";
+}
+
+sub _mail_key {
+    my ($self) = @_;
+    return $self->{parent}->{engine}->{current_file_rel};
+}
+
+1;

--- a/t/data/engine/parse_csv/00/reference-output/database/files
+++ b/t/data/engine/parse_csv/00/reference-output/database/files
@@ -1,0 +1,4 @@
+files
+{
+    0    1 1 parse_csv_00 test_namespace strings.csv 0
+}

--- a/t/data/engine/parse_csv/00/reference-output/database/items
+++ b/t/data/engine/parse_csv/00/reference-output/database/items
@@ -1,0 +1,9 @@
+items
+{
+    0    1 3 1 1 NO NO 0
+    1    2 5 1 2 NO NO 0
+    2    3 7 1 3 NO NO 0
+    3    4 9 1 4 NO NO 0
+    4    5 11 1 5 NO NO 0
+    5    6 13 1 6 NO NO 0
+}

--- a/t/data/engine/parse_csv/00/reference-output/database/properties
+++ b/t/data/engine/parse_csv/00/reference-output/database/properties
@@ -1,0 +1,23 @@
+properties
+{
+    0     1 source:1 f3850e8eb0d30b344a4d1d6b3db52a56
+    1     2 hash:1 f3850e8eb0d30b344a4d1d6b3db52a56
+    2     3 size:1 120
+    3     4 items:1 1,2,3,4,5,6
+    4     5 ts:1:test:count 6
+    5     6 usn:1:test 19
+    6     7 ts:1:test 86197ba45430c239e6ca3399273a09a6
+    7     8 target:1:parse_csv_00:test
+          f001c90139e341d09d2b8d87c7bd66c5
+    8     9 target:mtime:1:parse_csv_00:test 12345678
+    9     10 source:1:parse_csv_00:test
+          f3850e8eb0d30b344a4d1d6b3db52a56
+    10    11 source:ts:1:parse_csv_00:test
+          86197ba45430c239e6ca3399273a09a6
+    11    12 job-hash:test_namespace:parse_csv_00
+          8e52a15521683451984178cffe20236b
+    12    13 job-plugin:test_namespace:parse_csv_00 parse_csv.
+    13    14 job-serializer-plugin:test_namespace:parse_csv_00
+          serialize_po.
+    14    15 job-engine:test_namespace:parse_csv_00 1.2
+}

--- a/t/data/engine/parse_csv/00/reference-output/database/strings
+++ b/t/data/engine/parse_csv/00/reference-output/database/strings
@@ -1,0 +1,10 @@
+strings
+{
+    0    1 2 value1 string1 0
+    1    2 4 value,2 string2 0
+    2    3 6 '' string3 0
+    3    4 8 `line1
+line2` string4 0
+    4    5 10 " string5 0
+    5    6 12 ` ` string7 0
+}

--- a/t/data/engine/parse_csv/00/reference-output/database/translations
+++ b/t/data/engine/parse_csv/00/reference-output/database/translations
@@ -1,0 +1,10 @@
+translations
+{
+    0    1 14 1 test ṽáļũē1 NO 0 0
+    1    2 15 2 test ṽáļũē,2 NO 0 0
+    2    3 16 3 test '' NO 0 0
+    3    4 17 4 test `ļĩŋē1
+ļĩŋē2` NO 0 0
+    4    5 18 5 test " NO 0 0
+    5    6 19 6 test ` ` NO 0 0
+}

--- a/t/data/engine/parse_csv/00/reference-output/localized-resources/test/strings.csv
+++ b/t/data/engine/parse_csv/00/reference-output/localized-resources/test/strings.csv
@@ -1,0 +1,9 @@
+Key,String
+string1,"ṽáļũē1"
+string2,"ṽáļũē,2"
+string3,''
+string4,"ļĩŋē1
+ļĩŋē2"
+string5,""""
+string6,
+string7," "

--- a/t/data/engine/parse_csv/00/reference-output/po/test/strings.csv.po
+++ b/t/data/engine/parse_csv/00/reference-output/po/test/strings.csv.po
@@ -1,0 +1,46 @@
+msgid ""
+msgstr ""
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: test\n"
+"Generated-By: Serge 1.2\n"
+
+#: File: strings.csv
+#: ID: 0e06836499090f2f0713e983e3d42382
+msgctxt "string1"
+msgid "value1"
+msgstr "ṽáļũē1"
+
+#: File: strings.csv
+#: ID: fd1ffdab2afce98824086d9e0cd37ff0
+msgctxt "string2"
+msgid "value,2"
+msgstr "ṽáļũē,2"
+
+#: File: strings.csv
+#: ID: a9572d320f4fcf0828d05497d223415a
+msgctxt "string3"
+msgid "''"
+msgstr "''"
+
+#: File: strings.csv
+#: ID: e18daa468c420c818b4ffd850952ed58
+msgctxt "string4"
+msgid ""
+"line1\n"
+"line2"
+msgstr ""
+"ļĩŋē1\n"
+"ļĩŋē2"
+
+#: File: strings.csv
+#: ID: d6497771d1355a7a9f2dce4722c02998
+msgctxt "string5"
+msgid "\""
+msgstr "\""
+
+#: File: strings.csv
+#: ID: 3f2c82d2863391d63ceee71a34b21517
+msgctxt "string7"
+msgid " "
+msgstr " "

--- a/t/data/engine/parse_csv/00/resources/strings.csv
+++ b/t/data/engine/parse_csv/00/resources/strings.csv
@@ -1,0 +1,9 @@
+Key,String
+"string1",value1
+string2,"value,2"
+string3,"''"
+string4,"line1
+line2"
+string5,""""
+string6,
+string7, 

--- a/t/data/engine/parse_csv/00/translate.serge
+++ b/t/data/engine/parse_csv/00/translate.serge
@@ -1,0 +1,22 @@
+# Tests:
+# 1) Corner cases of CSV input
+# 2) parse_csv default configuration values
+
+jobs
+{
+    {
+        @inherit                        ../../common.serge#job_template
+
+        name                            Parse CSV Test 00
+        id                              parse_csv_00
+
+        source_process_subdirs          YES
+        source_match                    \.csv$
+        output_bom                      NO
+
+        parser
+        {
+            plugin                      parse_csv
+        }
+    }
+}

--- a/t/data/engine/parse_csv/01/reference-output/database/files
+++ b/t/data/engine/parse_csv/01/reference-output/database/files
@@ -1,0 +1,4 @@
+files
+{
+    0    1 1 parse_csv_02 test_namespace strings.csv 0
+}

--- a/t/data/engine/parse_csv/01/reference-output/database/items
+++ b/t/data/engine/parse_csv/01/reference-output/database/items
@@ -1,0 +1,4 @@
+items
+{
+    0    1 3 1 1 comment1 NO 0
+}

--- a/t/data/engine/parse_csv/01/reference-output/database/properties
+++ b/t/data/engine/parse_csv/01/reference-output/database/properties
@@ -1,0 +1,23 @@
+properties
+{
+    0     1 source:1 65bd01695acd6c0e5608d2f5396d6a04
+    1     2 hash:1 65bd01695acd6c0e5608d2f5396d6a04
+    2     3 size:1 70
+    3     4 items:1 1
+    4     5 ts:1:test:count 1
+    5     6 usn:1:test 4
+    6     7 ts:1:test 9ee34a95c44af8712592ed897c80e8e8
+    7     8 target:1:parse_csv_02:test
+          ab2c8a2d5e43cf8ab7993b7db5e5f7c2
+    8     9 target:mtime:1:parse_csv_02:test 12345678
+    9     10 source:1:parse_csv_02:test
+          65bd01695acd6c0e5608d2f5396d6a04
+    10    11 source:ts:1:parse_csv_02:test
+          9ee34a95c44af8712592ed897c80e8e8
+    11    12 job-hash:test_namespace:parse_csv_02
+          0bae7889c4c50b3de9303c400c64ba14
+    12    13 job-plugin:test_namespace:parse_csv_02 parse_csv.
+    13    14 job-serializer-plugin:test_namespace:parse_csv_02
+          serialize_po.
+    14    15 job-engine:test_namespace:parse_csv_02 1.2
+}

--- a/t/data/engine/parse_csv/01/reference-output/database/strings
+++ b/t/data/engine/parse_csv/01/reference-output/database/strings
@@ -1,0 +1,4 @@
+strings
+{
+    0    1 2 string1 context1 0
+}

--- a/t/data/engine/parse_csv/01/reference-output/database/translations
+++ b/t/data/engine/parse_csv/01/reference-output/database/translations
@@ -1,0 +1,4 @@
+translations
+{
+    0    1 4 1 test šţŕĩŋğ1 NO 0 0
+}

--- a/t/data/engine/parse_csv/01/reference-output/localized-resources/test/strings.csv
+++ b/t/data/engine/parse_csv/01/reference-output/localized-resources/test/strings.csv
@@ -1,0 +1,2 @@
+TheKey-TheString-TheContext-TheComment
+key1-"šţŕĩŋğ1"-context1-comment1

--- a/t/data/engine/parse_csv/01/reference-output/po/test/strings.csv.po
+++ b/t/data/engine/parse_csv/01/reference-output/po/test/strings.csv.po
@@ -1,0 +1,13 @@
+msgid ""
+msgstr ""
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: test\n"
+"Generated-By: Serge 1.2\n"
+
+#. comment1
+#: File: strings.csv
+#: ID: 5fc4428d4c9eda81531a0bb3a750cd48
+msgctxt "context1"
+msgid "string1"
+msgstr "šţŕĩŋğ1"

--- a/t/data/engine/parse_csv/01/resources/strings.csv
+++ b/t/data/engine/parse_csv/01/resources/strings.csv
@@ -1,0 +1,2 @@
+TheKey-TheString-TheContext-TheComment
+key1-string1-context1-comment1

--- a/t/data/engine/parse_csv/01/translate.serge
+++ b/t/data/engine/parse_csv/01/translate.serge
@@ -1,0 +1,30 @@
+# Tests parse_csv config settings.
+
+jobs
+{
+    {
+        @inherit                        ../../common.serge#job_template
+
+        name                            Parse CSV Test 02
+        id                              parse_csv_02
+
+        source_process_subdirs          YES
+        source_match                    \.csv$
+        output_bom                      NO
+
+        parser
+        {
+            plugin                      parse_csv
+
+            data
+            {
+                delimiter               -
+
+                column_key              TheKey
+                column_context          TheContext
+                column_string           TheString
+                column_comment          TheComment
+            }
+        }
+    }
+}


### PR DESCRIPTION
Implements #52.

I created this change with an Error Emailer role, but I removed it for this PR since it became more involved and will require a separate discussion.

Assumes one column is a unique key and another column is text.  This is the simplest case, and the only one I'm personally interested in.  Composite key columns, non-unique columns, and multiple text fields are possible future enhancements.