### PR TITLE
Test translation server (used for testing)

### DIFF
--- a/lib/Serge/Sync/Plugin/TranslationService/test.pm
+++ b/lib/Serge/Sync/Plugin/TranslationService/test.pm
@@ -1,0 +1,39 @@
+package Serge::Sync::Plugin::TranslationService::test;
+use parent Serge::Sync::Plugin::Base::TranslationService, Serge::Interface::SysCmdRunner;
+
+use strict;
+
+use Serge::Util qw(subst_macros);
+
+sub name {
+    return 'Test translation server (used for manual testing) synchronization plugin';
+}
+
+sub init {
+    my $self = shift;
+
+    $self->SUPER::init(@_);
+
+    $self->{optimizations} = 1; # set to undef to disable optimizations
+}
+
+sub print_command {
+    my ($self, $command) = @_;
+
+    print "Running '$command'...\n";
+    return 1;
+}
+
+sub pull_ts {
+    my ($self, $langs) = @_;
+
+    return $self->print_command("pull");
+}
+
+sub push_ts {
+    my ($self, $langs) = @_;
+
+    return $self->print_command("push");
+}
+
+1;


### PR DESCRIPTION
A does nothing translation server, so someone can use serge sync without connecting to any translation server. To be used when doing in place manual editing of the files. Needed this when writing the xliff 2 serializer as I do not have a plugin that supports xliff 2, but I can edit the files with Ocelot.