### PR TITLE
Add a Dockerfile to enable automatic builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,21 @@
+FROM alpine:3.7
+
+# # TODO: Docker Hub does not allow environment variables as Docker Cloud Does.
+# # For now, assume master = current SHA
+ENV SOURCE_BRANCH master
+
+RUN set -ex \
+    && apk add --no-cache perl perl-utils perl-dev make build-base openssl openssl-dev expat expat-dev \
+    && wget -O - https://github.com/evernote/serge/archive/${SOURCE_BRANCH}.tar.gz | tar zxf - \
+    && mv /serge-* /serge \
+    && yes | cpan App::cpanminus \
+    && cpanm --no-wget --installdeps /serge \
+    && rm -rf /root/.cpan* /usr/local/share/man \
+    && mkdir -p /data \
+    && cp /serge/doc/sample.serge /data \
+    && apk del -f --purge make build-base openssl-dev expat-dev
+
+ENV PATH="/serge/bin:${PATH}"
+VOLUME /data
+WORKDIR /data
+ENTRYPOINT /serge/bin/serge


### PR DESCRIPTION
I’d like to suggest adding a `Dockerfile` to the repository to facilitate folks using serge from a container, which simplifies installation dramatically, and also facilitates use by next-generation orchestration and cluster management platforms (Kubernetes, Rancher, Mesos, etc).

Further, adding it to the base repository unlocks the availability of automated container builds on Docker Hub every time master is updated or a release tagged. 

I’ve set up a [proof-of-concept Hub Registry](https://hub.docker.com/r/changeeng/serge/), but because I don’t have write access to the upstream repository, I can’t set up automated builds based on it.

I’d be more than happy to help you get the official hub set up so that builds are completely automatic.

[After being pulled off onto other projects for nearly 2 years, I’m dusting off my work on integrating Serge into our workflow. I’ll probably be quite a bit more active in the coming weeks & months as I come up to speed on what’s changed since then.]