### PR TITLE
Generic xslt (https://www.w3.org/Style/XSL/) replacement plugin

### DIFF
--- a/Build.PL
+++ b/Build.PL
@@ -19,6 +19,8 @@ my $builder = Module::Build->new(
         'Text::CSV_XS'       => 0,
         'Text::Diff'         => 0,
         'XML::Tidy'          => 0,
+        'XML::LibXSLT'        => 0,
+        'XML::LibXML'         => 0,
     },
     requires => {
         'perl'               => '5.10.0',

--- a/lib/Serge/Engine/Plugin/apply_xslt.pm
+++ b/lib/Serge/Engine/Plugin/apply_xslt.pm
@@ -1,0 +1,114 @@
+package Serge::Engine::Plugin::apply_xslt;
+use parent Serge::Engine::Plugin::if;
+
+use strict;
+use utf8;
+
+no warnings qw(uninitialized);
+
+use Encode qw(decode_utf8);
+use Serge::Util qw(subst_macros_strref xml_escape_strref xml_unescape_strref);
+
+sub name {
+    return 'Generic xslt (https://www.w3.org/Style/XSL/) replacement plugin';
+}
+
+sub init {
+    my $self = shift;
+
+    $self->SUPER::init(@_);
+
+    $self->merge_schema({
+        apply => {'' => 'LIST',
+            '*'        => 'STRING'
+        },
+        if => {
+            '*' => {
+                then => {
+                    apply => {'' => 'LIST',
+                        '*'        => 'STRING'
+                    },
+                },
+            },
+        },
+    });
+
+    $self->add({
+        after_load_file => \&check,
+        before_save_localized_file => \&check,
+    });
+
+    $self->{stylesheets} = {};
+}
+
+sub validate_data {
+    my ($self) = @_;
+
+    $self->SUPER::validate_data;
+
+    die "'apply' parameter is not specified and no 'if' blocks found" if !exists $self->{data}->{if} && !$self->{data}->{apply};
+
+    if (exists $self->{data}->{if}) {
+        foreach my $block (@{$self->{data}->{if}}) {
+            die "'apply' parameter is not specified inside if/then block" if !$block->{then}->{apply};
+        }
+    }
+
+    eval('use XML::LibXSLT;');
+    die "ERROR: To use the apply_xslt plugin, please install XML::LibXSLT module (run 'cpan XML::LibXSLT')\n" if $@;
+
+    eval('use XML::LibXML;');
+    die "ERROR: To use the apply_xslt plugin, please install XML::LibXML module (run 'cpan XML::LibXML')\n" if $@;
+}
+
+sub adjust_phases {
+    my ($self, $phases) = @_;
+
+    $self->SUPER::adjust_phases($phases);
+
+    # this plugin makes sense only when applied to a single phase
+    # (in addition to 'before_job' phase inherited from Serge::Engine::Plugin::if plugin)
+    die "This plugin needs to be attached to only one phase at a time" unless @$phases == 2;
+}
+
+sub process_then_block {
+    my ($self, $phase, $block, $file, $lang, $strref) = @_;
+
+    #print "::process_then_block(), phase=[$phase], block=[$block], file=[$file], lang=[$lang], strref=[$strref]\n";
+
+    my $parser = XML::LibXML->new();
+
+    my $source = $parser->parse_string($$strref);
+
+    my $apply_list = $block->{apply};
+    foreach my $xslt_filepath (@$apply_list) {
+
+        if (not exists $self->{stylesheets}->{$xslt_filepath}) {
+            my $xslt = XML::LibXSLT->new();
+
+            my $style_doc = $parser->parse_file($xslt_filepath);
+            my $stylesheet = $xslt->parse_stylesheet($style_doc);
+
+            $self->{stylesheets}->{$xslt_filepath} = $stylesheet;
+        }
+
+        my $stylesheet = $self->{stylesheets}->{$xslt_filepath};
+
+        $source = $stylesheet->transform($source);
+
+        my $source_as_string = $stylesheet->output_string($source);
+
+        $source_as_string = decode_utf8($source_as_string);
+
+        $$strref = $source_as_string;
+    }
+
+    return $self->SUPER::process_then_block(shift @_);
+}
+
+sub check {
+    my $self = shift;
+    return $self->SUPER::check(@_);
+}
+
+1;

--- a/t/data/engine/apply_xslt/00/README.md
+++ b/t/data/engine/apply_xslt/00/README.md
@@ -1,0 +1,1 @@
+Test for 'apply_xslt' plugin, 'after_load_file' phase

--- a/t/data/engine/apply_xslt/00/filter_only_translate.xslt
+++ b/t/data/engine/apply_xslt/00/filter_only_translate.xslt
@@ -1,0 +1,21 @@
+<?xml version="1.0"?>
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+    <xsl:output method="xml" indent="yes" />
+
+    <xsl:template match="/">
+        <xsl:apply-templates/>
+    </xsl:template>
+
+    <xsl:template match="resources">
+        <xsl:copy>
+            <xsl:apply-templates select="string[@comment='translate']"/>
+        </xsl:copy>
+    </xsl:template>
+
+    <xsl:template match="string">
+        <string>
+            <xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute>
+            <xsl:value-of select="."/>
+        </string>
+    </xsl:template>
+</xsl:stylesheet>

--- a/t/data/engine/apply_xslt/00/reference-output/database/files
+++ b/t/data/engine/apply_xslt/00/reference-output/database/files
@@ -1,0 +1,4 @@
+files
+{
+    0    1 1 test_job test_namespace strings.xml 0
+}

--- a/t/data/engine/apply_xslt/00/reference-output/database/items
+++ b/t/data/engine/apply_xslt/00/reference-output/database/items
@@ -1,0 +1,5 @@
+items
+{
+    0    1 3 1 1 string3 NO 0
+    1    2 5 1 2 string6 NO 0
+}

--- a/t/data/engine/apply_xslt/00/reference-output/database/properties
+++ b/t/data/engine/apply_xslt/00/reference-output/database/properties
@@ -1,0 +1,21 @@
+properties
+{
+    0     1 source:1 68c6a2b395e6d8ce4f9a791d04a2b213
+    1     2 hash:1 a324bc0a1b02dc43c70c5333c399bc91
+    2     3 size:1 430
+    3     4 items:1 1,2
+    4     5 ts:1:test:count 2
+    5     6 usn:1:test 6
+    6     7 ts:1:test fc058cf5b649d2f5c9765449c1b7dc0e
+    7     8 target:1:test_job:test e48d6863a960bed47f113ca37dc49efd
+    8     9 target:mtime:1:test_job:test 12345678
+    9     10 source:1:test_job:test 68c6a2b395e6d8ce4f9a791d04a2b213
+    10    11 source:ts:1:test_job:test
+          fc058cf5b649d2f5c9765449c1b7dc0e
+    11    12 job-hash:test_namespace:test_job
+          d616a690639dcc0814d13106931d4aec
+    12    13 job-plugin:test_namespace:test_job parse_android.
+    13    14 job-serializer-plugin:test_namespace:test_job
+          serialize_po.
+    14    15 job-engine:test_namespace:test_job 1.3.2
+}

--- a/t/data/engine/apply_xslt/00/reference-output/database/strings
+++ b/t/data/engine/apply_xslt/00/reference-output/database/strings
@@ -1,0 +1,5 @@
+strings
+{
+    0    1 2 `Value 3` NO 0
+    1    2 4 `Value 6` NO 0
+}

--- a/t/data/engine/apply_xslt/00/reference-output/database/translations
+++ b/t/data/engine/apply_xslt/00/reference-output/database/translations
@@ -1,0 +1,4 @@
+translations
+{
+    0    1 6 1 test `Test Translation 3` NO 0 0
+}

--- a/t/data/engine/apply_xslt/00/reference-output/localized-resources/test/strings.xml
+++ b/t/data/engine/apply_xslt/00/reference-output/localized-resources/test/strings.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0"?>
+<resources>
+  <string name="string3">Test Translation 3</string>
+  <string name="string6">Value 6</string>
+</resources>

--- a/t/data/engine/apply_xslt/00/reference-output/po/test/strings.xml.po
+++ b/t/data/engine/apply_xslt/00/reference-output/po/test/strings.xml.po
@@ -1,0 +1,18 @@
+msgid ""
+msgstr ""
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: test\n"
+"Generated-By: Serge 1.3\n"
+
+#. string3
+#: File: strings.xml
+#: ID: 2e920fe719df0296f38564a3a624f4fa
+msgid "Value 3"
+msgstr "Test Translation 3"
+
+#. string6
+#: File: strings.xml
+#: ID: 033f70ded0bee8c0b721dd3a6d87129f
+msgid "Value 6"
+msgstr ""

--- a/t/data/engine/apply_xslt/00/resources/strings.xml
+++ b/t/data/engine/apply_xslt/00/resources/strings.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="string1">Value 1</string>
+    <string name="string2">Value 2</string>
+    <string name="string3" comment="translate">Value 3</string>
+    <string name="string4">Value 4</string>
+    <string name="string5">Value 5</string>
+    <string name="string6" comment="translate">Value 6</string>
+    <string name="string7" comment="exclude">Value 7</string>
+</resources>

--- a/t/data/engine/apply_xslt/00/translate.serge
+++ b/t/data/engine/apply_xslt/00/translate.serge
@@ -1,0 +1,42 @@
+jobs
+{
+    {
+        @inherit                                 ../../common.serge#job_template
+        source_match                             \.xml$
+
+        parser
+        {
+            plugin                               parse_android
+        }
+
+        callback_plugins
+        {
+            :test_language
+            {
+                plugin                           test_language
+
+                data
+                {
+                    save_translations            YES
+
+                    translations
+                    {
+                        `Value 1`                `Test Translation 1`
+                        `Value 2`                `Test Translation 2`
+                        `Value 3`                `Test Translation 3`
+                    }
+                }
+            }
+
+            {
+                plugin                           apply_xslt
+                phase                            after_load_file
+
+                data
+                {
+                    apply                        ./filter_only_translate.xslt
+                }
+            }
+        }
+    }
+}

--- a/t/data/engine/apply_xslt/01/README.md
+++ b/t/data/engine/apply_xslt/01/README.md
@@ -1,0 +1,1 @@
+Test for 'apply_xslt' plugin, 'before_save_localized_file' phase, another XSLT transformation

--- a/t/data/engine/apply_xslt/01/filter_untranslated.xslt
+++ b/t/data/engine/apply_xslt/01/filter_untranslated.xslt
@@ -1,0 +1,21 @@
+<?xml version="1.0"?>
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+    <xsl:output method="xml" indent="yes" />
+
+    <xsl:output method="xml" version="1.0" encoding="utf-8" indent="yes"/>
+
+    <xsl:strip-space elements="*"/>
+
+    <xsl:template match="@*|node()">
+        <xsl:copy>
+            <xsl:apply-templates select="@*|node()"/>
+        </xsl:copy>
+    </xsl:template>
+
+    <xsl:template match="resources">
+        <xsl:copy>
+            <xsl:apply-templates select="string[. != '']"/>
+        </xsl:copy>
+    </xsl:template>
+
+</xsl:stylesheet>

--- a/t/data/engine/apply_xslt/01/reference-output/database/files
+++ b/t/data/engine/apply_xslt/01/reference-output/database/files
@@ -1,0 +1,4 @@
+files
+{
+    0    1 1 test_job test_namespace strings.xml 0
+}

--- a/t/data/engine/apply_xslt/01/reference-output/database/items
+++ b/t/data/engine/apply_xslt/01/reference-output/database/items
@@ -1,0 +1,10 @@
+items
+{
+    0    1 3 1 1 string1 NO 0
+    1    2 5 1 2 string2 NO 0
+    2    3 7 1 3 string3 NO 0
+    3    4 9 1 4 string4 NO 0
+    4    5 11 1 5 string5 NO 0
+    5    6 13 1 6 string6 NO 0
+    6    7 15 1 7 string7 NO 0
+}

--- a/t/data/engine/apply_xslt/01/reference-output/database/properties
+++ b/t/data/engine/apply_xslt/01/reference-output/database/properties
@@ -1,0 +1,21 @@
+properties
+{
+    0     1 source:1 a324bc0a1b02dc43c70c5333c399bc91
+    1     2 hash:1 a324bc0a1b02dc43c70c5333c399bc91
+    2     3 size:1 430
+    3     4 items:1 1,2,3,4,5,6,7
+    4     5 ts:1:test:count 7
+    5     6 usn:1:test 18
+    6     7 ts:1:test 6ff0e36699a3eb1ae0971b7765d7ac92
+    7     8 target:1:test_job:test 66e7f575655c53ac45f55d15be976a28
+    8     9 target:mtime:1:test_job:test 12345678
+    9     10 source:1:test_job:test a324bc0a1b02dc43c70c5333c399bc91
+    10    11 source:ts:1:test_job:test
+          6ff0e36699a3eb1ae0971b7765d7ac92
+    11    12 job-hash:test_namespace:test_job
+          b9cdc879fdebce524c7e15c122274a8a
+    12    13 job-plugin:test_namespace:test_job parse_android.
+    13    14 job-serializer-plugin:test_namespace:test_job
+          serialize_po.
+    14    15 job-engine:test_namespace:test_job 1.3.2
+}

--- a/t/data/engine/apply_xslt/01/reference-output/database/strings
+++ b/t/data/engine/apply_xslt/01/reference-output/database/strings
@@ -1,0 +1,10 @@
+strings
+{
+    0    1 2 `Value 1` NO 0
+    1    2 4 `Value 2` NO 0
+    2    3 6 `Value 3` NO 0
+    3    4 8 `Value 4` NO 0
+    4    5 10 `Value 5` NO 0
+    5    6 12 `Value 6` NO 0
+    6    7 14 `Value 7` NO 0
+}

--- a/t/data/engine/apply_xslt/01/reference-output/database/translations
+++ b/t/data/engine/apply_xslt/01/reference-output/database/translations
@@ -1,0 +1,6 @@
+translations
+{
+    0    1 16 1 test `Test Translation 1` NO 0 0
+    1    2 17 2 test `Test Translation 2` NO 0 0
+    2    3 18 3 test `Test Translation 3` NO 0 0
+}

--- a/t/data/engine/apply_xslt/01/reference-output/localized-resources/test/strings.xml
+++ b/t/data/engine/apply_xslt/01/reference-output/localized-resources/test/strings.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+  <string name="string1">Test Translation 1</string>
+  <string name="string2">Test Translation 2</string>
+  <string name="string3" comment="translate">Test Translation 3</string>
+</resources>

--- a/t/data/engine/apply_xslt/01/reference-output/po/test/strings.xml.po
+++ b/t/data/engine/apply_xslt/01/reference-output/po/test/strings.xml.po
@@ -1,0 +1,48 @@
+msgid ""
+msgstr ""
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: test\n"
+"Generated-By: Serge 1.3\n"
+
+#. string1
+#: File: strings.xml
+#: ID: 52b8425aa485a7e3b7a02e1b586f9cef
+msgid "Value 1"
+msgstr "Test Translation 1"
+
+#. string2
+#: File: strings.xml
+#: ID: 3fa07f98de1fb810037bfde267c704d1
+msgid "Value 2"
+msgstr "Test Translation 2"
+
+#. string3
+#: File: strings.xml
+#: ID: 2e920fe719df0296f38564a3a624f4fa
+msgid "Value 3"
+msgstr "Test Translation 3"
+
+#. string4
+#: File: strings.xml
+#: ID: bf5a11014de06a379dcb4fda0faa156d
+msgid "Value 4"
+msgstr ""
+
+#. string5
+#: File: strings.xml
+#: ID: 94ccaa970592240abdb17d60eda93e2f
+msgid "Value 5"
+msgstr ""
+
+#. string6
+#: File: strings.xml
+#: ID: 033f70ded0bee8c0b721dd3a6d87129f
+msgid "Value 6"
+msgstr ""
+
+#. string7
+#: File: strings.xml
+#: ID: cf87626660328addac27a006a2109e53
+msgid "Value 7"
+msgstr ""

--- a/t/data/engine/apply_xslt/01/resources/strings.xml
+++ b/t/data/engine/apply_xslt/01/resources/strings.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="string1">Value 1</string>
+    <string name="string2">Value 2</string>
+    <string name="string3" comment="translate">Value 3</string>
+    <string name="string4">Value 4</string>
+    <string name="string5">Value 5</string>
+    <string name="string6" comment="translate">Value 6</string>
+    <string name="string7" comment="exclude">Value 7</string>
+</resources>

--- a/t/data/engine/apply_xslt/01/translate.serge
+++ b/t/data/engine/apply_xslt/01/translate.serge
@@ -1,0 +1,42 @@
+jobs
+{
+    {
+        @inherit                                 ../../common.serge#job_template
+        source_match                             \.xml$
+        leave_untranslated_blank                 YES
+        parser
+        {
+            plugin                               parse_android
+        }
+
+        callback_plugins
+        {
+            :test_language
+            {
+                plugin                           test_language
+
+                data
+                {
+                    save_translations            YES
+
+                    translations
+                    {
+                        `Value 1`                `Test Translation 1`
+                        `Value 2`                `Test Translation 2`
+                        `Value 3`                `Test Translation 3`
+                    }
+                }
+            }
+
+            {
+                plugin                           apply_xslt
+                phase                            before_save_localized_file
+
+                data
+                {
+                    apply                        ./filter_untranslated.xslt
+                }
+            }
+        }
+    }
+}

--- a/t/data/engine/apply_xslt/02/README.md
+++ b/t/data/engine/apply_xslt/02/README.md
@@ -1,0 +1,1 @@
+Test for 'apply_xslt' plugin, 'before_save_localized_file' phase, multiple XSLT transformations

--- a/t/data/engine/apply_xslt/02/filter_untranslated.xslt
+++ b/t/data/engine/apply_xslt/02/filter_untranslated.xslt
@@ -1,0 +1,21 @@
+<?xml version="1.0"?>
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+    <xsl:output method="xml" indent="yes" />
+
+    <xsl:template match="/">
+        <xsl:apply-templates/>
+    </xsl:template>
+
+    <xsl:template match="resources">
+        <xsl:copy>
+            <xsl:copy-of select="string[. != '']"/>
+        </xsl:copy>
+    </xsl:template>
+
+    <xsl:template match="string">
+        <string>
+            <xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute>
+            <xsl:value-of select="."/>
+        </string>
+    </xsl:template>
+</xsl:stylesheet>

--- a/t/data/engine/apply_xslt/02/reference-output/database/files
+++ b/t/data/engine/apply_xslt/02/reference-output/database/files
@@ -1,0 +1,4 @@
+files
+{
+    0    1 1 test_job test_namespace strings.xml 0
+}

--- a/t/data/engine/apply_xslt/02/reference-output/database/items
+++ b/t/data/engine/apply_xslt/02/reference-output/database/items
@@ -1,0 +1,10 @@
+items
+{
+    0    1 3 1 1 string1 NO 0
+    1    2 5 1 2 string2 NO 0
+    2    3 7 1 3 string3 NO 0
+    3    4 9 1 4 string4 NO 0
+    4    5 11 1 5 string5 NO 0
+    5    6 13 1 6 string6 NO 0
+    6    7 15 1 7 string7 NO 0
+}

--- a/t/data/engine/apply_xslt/02/reference-output/database/properties
+++ b/t/data/engine/apply_xslt/02/reference-output/database/properties
@@ -1,0 +1,21 @@
+properties
+{
+    0     1 source:1 62bad5482329999bb2085ad82063820c
+    1     2 hash:1 62bad5482329999bb2085ad82063820c
+    2     3 size:1 421
+    3     4 items:1 1,2,3,4,5,6,7
+    4     5 ts:1:test:count 7
+    5     6 usn:1:test 18
+    6     7 ts:1:test 02715d0d040106366df4d7a15d854914
+    7     8 target:1:test_job:test 4e326e1d363e6ab368727d022be29af4
+    8     9 target:mtime:1:test_job:test 12345678
+    9     10 source:1:test_job:test 62bad5482329999bb2085ad82063820c
+    10    11 source:ts:1:test_job:test
+          02715d0d040106366df4d7a15d854914
+    11    12 job-hash:test_namespace:test_job
+          054bebe933981954e09b8944047bbcb9
+    12    13 job-plugin:test_namespace:test_job parse_android.
+    13    14 job-serializer-plugin:test_namespace:test_job
+          serialize_po.
+    14    15 job-engine:test_namespace:test_job 1.3.2
+}

--- a/t/data/engine/apply_xslt/02/reference-output/database/strings
+++ b/t/data/engine/apply_xslt/02/reference-output/database/strings
@@ -1,0 +1,10 @@
+strings
+{
+    0    1 2 `Value 1` NO 0
+    1    2 4 `Value 2` NO 0
+    2    3 6 `Value 3` NO 0
+    3    4 8 `Value 4` NO 0
+    4    5 10 `Value 5` NO 0
+    5    6 12 `Value 6` NO 0
+    6    7 14 `Value 7` NO 0
+}

--- a/t/data/engine/apply_xslt/02/reference-output/database/translations
+++ b/t/data/engine/apply_xslt/02/reference-output/database/translations
@@ -1,0 +1,6 @@
+translations
+{
+    0    1 16 1 test `Translation 1` NO 0 0
+    1    2 17 2 test `Translation 2` NO 0 0
+    2    3 18 3 test `Translation 3` NO 0 0
+}

--- a/t/data/engine/apply_xslt/02/reference-output/localized-resources/test/strings.xml
+++ b/t/data/engine/apply_xslt/02/reference-output/localized-resources/test/strings.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0"?>
+<resources>
+  <string name="string1">Translation 1</string>
+  <string name="string2">Translation 2</string>
+  <string name="string3">Translation 3</string>
+</resources>

--- a/t/data/engine/apply_xslt/02/reference-output/po/test/strings.xml.po
+++ b/t/data/engine/apply_xslt/02/reference-output/po/test/strings.xml.po
@@ -1,0 +1,48 @@
+msgid ""
+msgstr ""
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: test\n"
+"Generated-By: Serge 1.3\n"
+
+#. string1
+#: File: strings.xml
+#: ID: 52b8425aa485a7e3b7a02e1b586f9cef
+msgid "Value 1"
+msgstr "Translation 1"
+
+#. string2
+#: File: strings.xml
+#: ID: 3fa07f98de1fb810037bfde267c704d1
+msgid "Value 2"
+msgstr "Translation 2"
+
+#. string3
+#: File: strings.xml
+#: ID: 2e920fe719df0296f38564a3a624f4fa
+msgid "Value 3"
+msgstr "Translation 3"
+
+#. string4
+#: File: strings.xml
+#: ID: bf5a11014de06a379dcb4fda0faa156d
+msgid "Value 4"
+msgstr ""
+
+#. string5
+#: File: strings.xml
+#: ID: 94ccaa970592240abdb17d60eda93e2f
+msgid "Value 5"
+msgstr ""
+
+#. string6
+#: File: strings.xml
+#: ID: 033f70ded0bee8c0b721dd3a6d87129f
+msgid "Value 6"
+msgstr ""
+
+#. string7
+#: File: strings.xml
+#: ID: cf87626660328addac27a006a2109e53
+msgid "Value 7"
+msgstr ""

--- a/t/data/engine/apply_xslt/02/remove_comment.xslt
+++ b/t/data/engine/apply_xslt/02/remove_comment.xslt
@@ -1,0 +1,21 @@
+<?xml version="1.0"?>
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+    <xsl:output method="xml" indent="yes" />
+
+    <xsl:template match="/">
+        <xsl:apply-templates/>
+    </xsl:template>
+
+    <xsl:template match="resources">
+        <xsl:copy>
+            <xsl:apply-templates select="string"/>
+        </xsl:copy>
+    </xsl:template>
+
+    <xsl:template match="string">
+        <string>
+            <xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute>
+            <xsl:value-of select="."/>
+        </string>
+    </xsl:template>
+</xsl:stylesheet>

--- a/t/data/engine/apply_xslt/02/resources/strings.xml
+++ b/t/data/engine/apply_xslt/02/resources/strings.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="string1">Value 1</string>
+    <string name="string2">Value 2</string>
+    <string name="string3" comment="first">Value 3</string>
+    <string name="string4">Value 4</string>
+    <string name="string5">Value 5</string>
+    <string name="string6" comment="second">Value 6</string>
+    <string name="string7" comment="third">Value 7</string>
+</resources>

--- a/t/data/engine/apply_xslt/02/translate.serge
+++ b/t/data/engine/apply_xslt/02/translate.serge
@@ -1,0 +1,43 @@
+jobs
+{
+    {
+        @inherit                                 ../../common.serge#job_template
+        source_match                             \.xml$
+        leave_untranslated_blank                 YES
+        parser
+        {
+            plugin                               parse_android
+        }
+
+        callback_plugins
+        {
+            :test_language
+            {
+                plugin                           test_language
+
+                data
+                {
+                    save_translations            YES
+
+                    translations
+                    {
+                        `Value 1`                `Translation 1`
+                        `Value 2`                `Translation 2`
+                        `Value 3`                `Translation 3`
+                    }
+                }
+            }
+
+            {
+                plugin                           apply_xslt
+                phase                            before_save_localized_file
+
+                data
+                {
+                    apply                        ./filter_untranslated.xslt
+                    apply                        ./remove_comment.xslt
+                }
+            }
+        }
+    }
+}

--- a/t/data/engine/apply_xslt/03/README.md
+++ b/t/data/engine/apply_xslt/03/README.md
@@ -1,0 +1,1 @@
+Test for 'apply_xslt' plugin, 'before_save_localized_file' phase, multiple resources

--- a/t/data/engine/apply_xslt/03/filter_untranslated.xslt
+++ b/t/data/engine/apply_xslt/03/filter_untranslated.xslt
@@ -1,0 +1,21 @@
+<?xml version="1.0"?>
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+    <xsl:output method="xml" indent="yes" />
+
+    <xsl:template match="/">
+        <xsl:apply-templates/>
+    </xsl:template>
+
+    <xsl:template match="resources">
+        <xsl:copy>
+            <xsl:copy-of select="string[. != '']"/>
+        </xsl:copy>
+    </xsl:template>
+
+    <xsl:template match="string">
+        <string>
+            <xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute>
+            <xsl:value-of select="."/>
+        </string>
+    </xsl:template>
+</xsl:stylesheet>

--- a/t/data/engine/apply_xslt/03/reference-output/database/files
+++ b/t/data/engine/apply_xslt/03/reference-output/database/files
@@ -1,0 +1,5 @@
+files
+{
+    0    1 1 test_job test_namespace strings1.xml 0
+    1    2 8 test_job test_namespace strings2.xml 0
+}

--- a/t/data/engine/apply_xslt/03/reference-output/database/items
+++ b/t/data/engine/apply_xslt/03/reference-output/database/items
@@ -1,0 +1,10 @@
+items
+{
+    0    1 3 1 1 string1 NO 0
+    1    2 5 1 2 string2 NO 0
+    2    3 7 1 3 string7 NO 0
+    3    4 10 2 4 string3 NO 0
+    4    5 12 2 5 string4 NO 0
+    5    6 14 2 6 string5 NO 0
+    6    7 16 2 7 string6 NO 0
+}

--- a/t/data/engine/apply_xslt/03/reference-output/database/properties
+++ b/t/data/engine/apply_xslt/03/reference-output/database/properties
@@ -1,0 +1,33 @@
+properties
+{
+    0     1 source:1 dc077fcc9cca7b2a3a350952d54201fa
+    1     2 hash:1 dc077fcc9cca7b2a3a350952d54201fa
+    2     3 size:1 212
+    3     4 items:1 1,2,3
+    4     5 source:2 438fa64398e5d33a34618ac32065950b
+    5     6 hash:2 438fa64398e5d33a34618ac32065950b
+    6     7 size:2 270
+    7     8 items:2 4,5,6,7
+    8     9 ts:1:test:count 3
+    9     10 usn:1:test 18
+    10    11 ts:1:test ac9df48f6079a8dd960a8ec7f51723ea
+    11    12 ts:2:test:count 4
+    12    13 usn:2:test 19
+    13    14 ts:2:test 3123404a8f8ef4fd7ab20a6c865ae310
+    14    15 target:1:test_job:test 2c92b10a63608306b1047163a623cd9e
+    15    16 target:mtime:1:test_job:test 12345678
+    16    17 source:1:test_job:test dc077fcc9cca7b2a3a350952d54201fa
+    17    18 source:ts:1:test_job:test
+          ac9df48f6079a8dd960a8ec7f51723ea
+    18    19 target:2:test_job:test 46a58132ec35465e2f3430c6767ea354
+    19    20 target:mtime:2:test_job:test 12345678
+    20    21 source:2:test_job:test 438fa64398e5d33a34618ac32065950b
+    21    22 source:ts:2:test_job:test
+          3123404a8f8ef4fd7ab20a6c865ae310
+    22    23 job-hash:test_namespace:test_job
+          1ebf5fd39eae21e80e2117cdfebfaa0b
+    23    24 job-plugin:test_namespace:test_job parse_android.
+    24    25 job-serializer-plugin:test_namespace:test_job
+          serialize_po.
+    25    26 job-engine:test_namespace:test_job 1.3.2
+}

--- a/t/data/engine/apply_xslt/03/reference-output/database/strings
+++ b/t/data/engine/apply_xslt/03/reference-output/database/strings
@@ -1,0 +1,10 @@
+strings
+{
+    0    1 2 `Value 1` NO 0
+    1    2 4 `Value 2` NO 0
+    2    3 6 `Value 7` NO 0
+    3    4 9 `Value 3` NO 0
+    4    5 11 `Value 4` NO 0
+    5    6 13 `Value 5` NO 0
+    6    7 15 `Value 6` NO 0
+}

--- a/t/data/engine/apply_xslt/03/reference-output/database/translations
+++ b/t/data/engine/apply_xslt/03/reference-output/database/translations
@@ -1,0 +1,6 @@
+translations
+{
+    0    1 17 1 test `Translation 1` NO 0 0
+    1    2 18 2 test `Translation 2` NO 0 0
+    2    3 19 4 test `Translation 3` NO 0 0
+}

--- a/t/data/engine/apply_xslt/03/reference-output/localized-resources/test/strings1.xml
+++ b/t/data/engine/apply_xslt/03/reference-output/localized-resources/test/strings1.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0"?>
+<resources>
+  <string name="string1">Translation 1</string>
+  <string name="string2">Translation 2</string>
+</resources>

--- a/t/data/engine/apply_xslt/03/reference-output/localized-resources/test/strings2.xml
+++ b/t/data/engine/apply_xslt/03/reference-output/localized-resources/test/strings2.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0"?>
+<resources>
+  <string name="string3" comment="third">Translation 3</string>
+</resources>

--- a/t/data/engine/apply_xslt/03/reference-output/po/test/strings1.xml.po
+++ b/t/data/engine/apply_xslt/03/reference-output/po/test/strings1.xml.po
@@ -1,0 +1,24 @@
+msgid ""
+msgstr ""
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: test\n"
+"Generated-By: Serge 1.3\n"
+
+#. string1
+#: File: strings1.xml
+#: ID: 52b8425aa485a7e3b7a02e1b586f9cef
+msgid "Value 1"
+msgstr "Translation 1"
+
+#. string2
+#: File: strings1.xml
+#: ID: 3fa07f98de1fb810037bfde267c704d1
+msgid "Value 2"
+msgstr "Translation 2"
+
+#. string7
+#: File: strings1.xml
+#: ID: cf87626660328addac27a006a2109e53
+msgid "Value 7"
+msgstr ""

--- a/t/data/engine/apply_xslt/03/reference-output/po/test/strings2.xml.po
+++ b/t/data/engine/apply_xslt/03/reference-output/po/test/strings2.xml.po
@@ -1,0 +1,30 @@
+msgid ""
+msgstr ""
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: test\n"
+"Generated-By: Serge 1.3\n"
+
+#. string3
+#: File: strings2.xml
+#: ID: 2e920fe719df0296f38564a3a624f4fa
+msgid "Value 3"
+msgstr "Translation 3"
+
+#. string4
+#: File: strings2.xml
+#: ID: bf5a11014de06a379dcb4fda0faa156d
+msgid "Value 4"
+msgstr ""
+
+#. string5
+#: File: strings2.xml
+#: ID: 94ccaa970592240abdb17d60eda93e2f
+msgid "Value 5"
+msgstr ""
+
+#. string6
+#: File: strings2.xml
+#: ID: 033f70ded0bee8c0b721dd3a6d87129f
+msgid "Value 6"
+msgstr ""

--- a/t/data/engine/apply_xslt/03/resources/strings1.xml
+++ b/t/data/engine/apply_xslt/03/resources/strings1.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="string1">Value 1</string>
+    <string name="string2">Value 2</string>
+    <string name="string7" comment="seven">Value 7</string>
+</resources>

--- a/t/data/engine/apply_xslt/03/resources/strings2.xml
+++ b/t/data/engine/apply_xslt/03/resources/strings2.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="string3" comment="third">Value 3</string>
+    <string name="string4">Value 4</string>
+    <string name="string5">Value 5</string>
+    <string name="string6" comment="six">Value 6</string>
+</resources>

--- a/t/data/engine/apply_xslt/03/translate.serge
+++ b/t/data/engine/apply_xslt/03/translate.serge
@@ -1,0 +1,42 @@
+jobs
+{
+    {
+        @inherit                                 ../../common.serge#job_template
+        source_match                             \.xml$
+        leave_untranslated_blank                 YES
+        parser
+        {
+            plugin                               parse_android
+        }
+
+        callback_plugins
+        {
+            :test_language
+            {
+                plugin                           test_language
+
+                data
+                {
+                    save_translations            YES
+
+                    translations
+                    {
+                        `Value 1`                `Translation 1`
+                        `Value 2`                `Translation 2`
+                        `Value 3`                `Translation 3`
+                    }
+                }
+            }
+
+            {
+                plugin                           apply_xslt
+                phase                            before_save_localized_file
+
+                data
+                {
+                    apply                        ./filter_untranslated.xslt
+                }
+            }
+        }
+    }
+}

--- a/t/data/engine/apply_xslt/04/README.md
+++ b/t/data/engine/apply_xslt/04/README.md
@@ -1,0 +1,1 @@
+Test for 'apply_xslt' plugin, 'before_save_localized_file' phase, invalid resource (non-xml)

--- a/t/data/engine/apply_xslt/04/filter_untranslated.xslt
+++ b/t/data/engine/apply_xslt/04/filter_untranslated.xslt
@@ -1,0 +1,21 @@
+<?xml version="1.0"?>
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+    <xsl:output method="xml" indent="yes" />
+
+    <xsl:template match="/">
+        <xsl:apply-templates/>
+    </xsl:template>
+
+    <xsl:template match="resources">
+        <xsl:copy>
+            <xsl:copy-of select="string[. != '']"/>
+        </xsl:copy>
+    </xsl:template>
+
+    <xsl:template match="string">
+        <string>
+            <xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute>
+            <xsl:value-of select="."/>
+        </string>
+    </xsl:template>
+</xsl:stylesheet>

--- a/t/data/engine/apply_xslt/04/reference-output/database/files
+++ b/t/data/engine/apply_xslt/04/reference-output/database/files
@@ -1,0 +1,4 @@
+files
+{
+    0    1 1 test_job test_namespace invalid_strings.xml 0
+}

--- a/t/data/engine/apply_xslt/04/reference-output/database/items
+++ b/t/data/engine/apply_xslt/04/reference-output/database/items
@@ -1,0 +1,6 @@
+items
+{
+    0    1 3 1 1 string1 NO 0
+    1    2 5 1 2 string2 NO 0
+    2    3 7 1 3 string7 NO 0
+}

--- a/t/data/engine/apply_xslt/04/reference-output/database/properties
+++ b/t/data/engine/apply_xslt/04/reference-output/database/properties
@@ -1,0 +1,10 @@
+properties
+{
+    0    1 source:1 a7396c859eabbd8f92200c8f00312287
+    1    2 hash:1 a7396c859eabbd8f92200c8f00312287
+    2    3 size:1 200
+    3    4 items:1 1,2,3
+    4    5 ts:1:test:count 3
+    5    6 usn:1:test 10
+    6    7 ts:1:test 1fce11969a808398094b27f2b022399f
+}

--- a/t/data/engine/apply_xslt/04/reference-output/database/strings
+++ b/t/data/engine/apply_xslt/04/reference-output/database/strings
@@ -1,0 +1,6 @@
+strings
+{
+    0    1 2 `Value 1` NO 0
+    1    2 4 `Value 2` NO 0
+    2    3 6 `Value 7` NO 0
+}

--- a/t/data/engine/apply_xslt/04/reference-output/database/translations
+++ b/t/data/engine/apply_xslt/04/reference-output/database/translations
@@ -1,0 +1,6 @@
+translations
+{
+    0    1 8 1 test `Ṽáļũē 1` NO 0 0
+    1    2 9 2 test `Ṽáļũē 2` NO 0 0
+    2    3 10 3 test `Ṽáļũē 7` NO 0 0
+}

--- a/t/data/engine/apply_xslt/04/reference-output/errors/test_job.txt
+++ b/t/data/engine/apply_xslt/04/reference-output/errors/test_job.txt
@@ -1,0 +1,3 @@
+:7: parser error : Premature end of data in tag resources line 2
+
+^

--- a/t/data/engine/apply_xslt/04/reference-output/po/test/invalid_strings.xml.po
+++ b/t/data/engine/apply_xslt/04/reference-output/po/test/invalid_strings.xml.po
@@ -1,0 +1,24 @@
+msgid ""
+msgstr ""
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: test\n"
+"Generated-By: Serge 1.3\n"
+
+#. string1
+#: File: invalid_strings.xml
+#: ID: 52b8425aa485a7e3b7a02e1b586f9cef
+msgid "Value 1"
+msgstr "Ṽáļũē 1"
+
+#. string2
+#: File: invalid_strings.xml
+#: ID: 3fa07f98de1fb810037bfde267c704d1
+msgid "Value 2"
+msgstr "Ṽáļũē 2"
+
+#. string7
+#: File: invalid_strings.xml
+#: ID: cf87626660328addac27a006a2109e53
+msgid "Value 7"
+msgstr "Ṽáļũē 7"

--- a/t/data/engine/apply_xslt/04/resources/invalid_strings.xml
+++ b/t/data/engine/apply_xslt/04/resources/invalid_strings.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="string1">Value 1</string>
+    <string name="string2">Value 2</string>
+    <string name="string7" comment="seven">Value 7</string>
+

--- a/t/data/engine/apply_xslt/04/translate.serge
+++ b/t/data/engine/apply_xslt/04/translate.serge
@@ -1,0 +1,25 @@
+jobs
+{
+    {
+        @inherit                                 ../../common.serge#job_template
+        source_match                             \.xml$
+
+        parser
+        {
+            plugin                               parse_android
+        }
+
+        callback_plugins
+        {
+            {
+                plugin                           apply_xslt
+                phase                            before_save_localized_file
+
+                data
+                {
+                    apply                        ./filter_untranslated.xslt
+                }
+            }
+        }
+    }
+}

--- a/t/data/engine/apply_xslt/05/README.md
+++ b/t/data/engine/apply_xslt/05/README.md
@@ -1,0 +1,1 @@
+Test for 'apply_xslt' plugin, 'before_save_localized_file' phase, invalid xslt

--- a/t/data/engine/apply_xslt/05/invalid.xslt
+++ b/t/data/engine/apply_xslt/05/invalid.xslt
@@ -1,0 +1,21 @@
+<?xml version="1.0"?>
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+    <xsl:output method="xml" indent="yes" />
+
+    <xsl:template invalid>
+        <xsl:apply-templates/>
+    </xsl:template>
+
+    <xsl:template match="resources">
+        <xsl:copy>
+            <xsl:copy-of select="string[. != '']"/>
+        </xsl:copy>
+    </xsl:template>
+
+    <xsl:template match="string">
+        <string>
+            <xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute>
+            <xsl:value-of select="."/>
+        </string>
+    </xsl:template>
+</xsl:stylesheet>

--- a/t/data/engine/apply_xslt/05/reference-output/database/files
+++ b/t/data/engine/apply_xslt/05/reference-output/database/files
@@ -1,0 +1,4 @@
+files
+{
+    0    1 1 test_job test_namespace strings1.xml 0
+}

--- a/t/data/engine/apply_xslt/05/reference-output/database/items
+++ b/t/data/engine/apply_xslt/05/reference-output/database/items
@@ -1,0 +1,6 @@
+items
+{
+    0    1 3 1 1 string1 NO 0
+    1    2 5 1 2 string2 NO 0
+    2    3 7 1 3 string7 NO 0
+}

--- a/t/data/engine/apply_xslt/05/reference-output/database/properties
+++ b/t/data/engine/apply_xslt/05/reference-output/database/properties
@@ -1,0 +1,10 @@
+properties
+{
+    0    1 source:1 dc077fcc9cca7b2a3a350952d54201fa
+    1    2 hash:1 dc077fcc9cca7b2a3a350952d54201fa
+    2    3 size:1 212
+    3    4 items:1 1,2,3
+    4    5 ts:1:test:count 3
+    5    6 usn:1:test 10
+    6    7 ts:1:test a429c823492b02e12e9af68f97b33850
+}

--- a/t/data/engine/apply_xslt/05/reference-output/database/strings
+++ b/t/data/engine/apply_xslt/05/reference-output/database/strings
@@ -1,0 +1,6 @@
+strings
+{
+    0    1 2 `Value 1` NO 0
+    1    2 4 `Value 2` NO 0
+    2    3 6 `Value 7` NO 0
+}

--- a/t/data/engine/apply_xslt/05/reference-output/database/translations
+++ b/t/data/engine/apply_xslt/05/reference-output/database/translations
@@ -1,0 +1,6 @@
+translations
+{
+    0    1 8 1 test `Ṽáļũē 1` NO 0 0
+    1    2 9 2 test `Ṽáļũē 2` NO 0 0
+    2    3 10 3 test `Ṽáļũē 7` NO 0 0
+}

--- a/t/data/engine/apply_xslt/05/reference-output/errors/test_job.txt
+++ b/t/data/engine/apply_xslt/05/reference-output/errors/test_job.txt
@@ -1,0 +1,3 @@
+./invalid.xslt:5: parser error : Specification mandate value for attribute invalid
+    <xsl:template invalid>
+                         ^

--- a/t/data/engine/apply_xslt/05/reference-output/po/test/strings1.xml.po
+++ b/t/data/engine/apply_xslt/05/reference-output/po/test/strings1.xml.po
@@ -1,0 +1,24 @@
+msgid ""
+msgstr ""
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: test\n"
+"Generated-By: Serge 1.3\n"
+
+#. string1
+#: File: strings1.xml
+#: ID: 52b8425aa485a7e3b7a02e1b586f9cef
+msgid "Value 1"
+msgstr "Ṽáļũē 1"
+
+#. string2
+#: File: strings1.xml
+#: ID: 3fa07f98de1fb810037bfde267c704d1
+msgid "Value 2"
+msgstr "Ṽáļũē 2"
+
+#. string7
+#: File: strings1.xml
+#: ID: cf87626660328addac27a006a2109e53
+msgid "Value 7"
+msgstr "Ṽáļũē 7"

--- a/t/data/engine/apply_xslt/05/resources/strings1.xml
+++ b/t/data/engine/apply_xslt/05/resources/strings1.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="string1">Value 1</string>
+    <string name="string2">Value 2</string>
+    <string name="string7" comment="seven">Value 7</string>
+</resources>

--- a/t/data/engine/apply_xslt/05/translate.serge
+++ b/t/data/engine/apply_xslt/05/translate.serge
@@ -1,0 +1,25 @@
+jobs
+{
+    {
+        @inherit                                 ../../common.serge#job_template
+        source_match                             \.xml$
+
+        parser
+        {
+            plugin                               parse_android
+        }
+
+        callback_plugins
+        {
+            {
+                plugin                           apply_xslt
+                phase                            before_save_localized_file
+
+                data
+                {
+                    apply                        ./invalid.xslt
+                }
+            }
+        }
+    }
+}

--- a/t/data/engine/apply_xslt/06/README.md
+++ b/t/data/engine/apply_xslt/06/README.md
@@ -1,0 +1,3 @@
+Test for 'apply_xslt' plugin, 'before_save_localized_file' phase for XML-unsafe chars
+
+Uses an identity transform (copies the source data into the destination data without change), so that only xml parsing issues should be visible.

--- a/t/data/engine/apply_xslt/06/copy.xslt
+++ b/t/data/engine/apply_xslt/06/copy.xslt
@@ -1,0 +1,9 @@
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+    <xsl:output cdata-section-elements="test" />
+
+    <xsl:template match="@*|node()">
+        <xsl:copy>
+            <xsl:apply-templates select="@*|node()"/>
+        </xsl:copy>
+    </xsl:template>
+</xsl:stylesheet>

--- a/t/data/engine/apply_xslt/06/reference-output/database/files
+++ b/t/data/engine/apply_xslt/06/reference-output/database/files
@@ -1,0 +1,4 @@
+files
+{
+    0    1 1 test_job test_namespace strings.xml 0
+}

--- a/t/data/engine/apply_xslt/06/reference-output/database/items
+++ b/t/data/engine/apply_xslt/06/reference-output/database/items
@@ -1,0 +1,10 @@
+items
+{
+    0    1 3 1 1 /item/name NO 0
+    1    2 5 1 2 /item/name NO 0
+    2    3 7 1 3 /item/test NO 0
+    3    4 9 1 4 /item/test NO 0
+    4    5 11 1 5 /item/linknames/activation NO 0
+    5    6 13 1 6 /item/linknames/homepage NO 0
+    6    7 15 1 7 /item/linknames/support NO 0
+}

--- a/t/data/engine/apply_xslt/06/reference-output/database/properties
+++ b/t/data/engine/apply_xslt/06/reference-output/database/properties
@@ -1,0 +1,21 @@
+properties
+{
+    0     1 source:1 d78df5ac8ac06c4c034722f2bc3742a5
+    1     2 hash:1 d78df5ac8ac06c4c034722f2bc3742a5
+    2     3 size:1 1024
+    3     4 items:1 1,2,3,4,5,6,7
+    4     5 ts:1:test:count 7
+    5     6 usn:1:test 20
+    6     7 ts:1:test 0a54d8d85c563b88860f15ed950527a8
+    7     8 target:1:test_job:test ed4928e1c8ddcfb4dad147f5490023e8
+    8     9 target:mtime:1:test_job:test 12345678
+    9     10 source:1:test_job:test d78df5ac8ac06c4c034722f2bc3742a5
+    10    11 source:ts:1:test_job:test
+          0a54d8d85c563b88860f15ed950527a8
+    11    12 job-hash:test_namespace:test_job
+          f2d2fbf456b4dcb8278d4344f44974f0
+    12    13 job-plugin:test_namespace:test_job parse_xml.
+    13    14 job-serializer-plugin:test_namespace:test_job
+          serialize_po.
+    14    15 job-engine:test_namespace:test_job 1.3.2
+}

--- a/t/data/engine/apply_xslt/06/reference-output/database/strings
+++ b/t/data/engine/apply_xslt/06/reference-output/database/strings
@@ -1,0 +1,10 @@
+strings
+{
+    0    1 2 Gadget NO 0
+    1    2 4 test NO 0
+    2    3 6 <p>&lt;foo/&gt;</p> NO 0
+    3    4 8 <foo/> NO 0
+    4    5 10 `Buy Now` NO 0
+    5    6 12 `Gadget Website` NO 0
+    6    7 14 `Gadget Support` NO 0
+}

--- a/t/data/engine/apply_xslt/06/reference-output/database/translations
+++ b/t/data/engine/apply_xslt/06/reference-output/database/translations
@@ -1,0 +1,8 @@
+translations
+{
+    0    1 16 1 test Dispositivo NO 0 0
+    1    2 17 2 test prova NO 0 0
+    2    3 18 3 test <p>&lt;nuovo/&gt;</p> NO 0 0
+    3    4 19 4 test <foo/> NO 0 0
+    4    5 20 5 test `Acquista adesso` NO 0 0
+}

--- a/t/data/engine/apply_xslt/06/reference-output/localized-resources/test/strings.xml
+++ b/t/data/engine/apply_xslt/06/reference-output/localized-resources/test/strings.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0"?>
+<!-- This is a comment-->
+<item type="hardware">
+    <id>Gadget</id>
+    <org>ACME Corp.</org>
+    <name>Dispositivo<!--prova--></name>
+    <categories>
+        <category>hardware</category>
+    </categories>
+    <added/>
+    <langs>en,fr,ja</langs>
+    <shortdesc>Gadget from ACME</shortdesc>
+    <longdesc>&lt;p&gt;Gadget from ACME can foo and bar.&lt;/p&gt;&lt;p&gt;Foo and bar without baz!&lt;/p&gt;</longdesc>
+    <test><![CDATA[<p>&lt;nuovo/&gt;</p>]]></test>
+    <test><![CDATA[<foo/>]]></test>
+    <smallimg>http:/example.com/gadget-small.png</smallimg>
+    <largeimg>http:/example.com/gadget-large.png</largeimg>
+    <linknames>
+	   <activation>Acquista adesso</activation>
+	   <blog>Blog Post</blog>
+	   <homepage>Gadget Website</homepage>
+	   <support>Gadget Support</support>
+    </linknames>
+    <links>
+        <en>
+            <activation> http://acme.com/products/gadget/shop </activation>
+            <blog>http://blog.acme.com/tag/gadget/</blog>
+        </en>
+    </links>
+</item>

--- a/t/data/engine/apply_xslt/06/reference-output/po/test/strings.xml.po
+++ b/t/data/engine/apply_xslt/06/reference-output/po/test/strings.xml.po
@@ -1,0 +1,48 @@
+msgid ""
+msgstr ""
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: test\n"
+"Generated-By: Serge 1.3\n"
+
+#. /item/name
+#: File: strings.xml
+#: ID: ef0b50fa37872c3f752a75fdca3b5bcd
+msgid "Gadget"
+msgstr "Dispositivo"
+
+#. /item/name
+#: File: strings.xml
+#: ID: d4962e0a3426ad69a6e8a923fbc9adfe
+msgid "test"
+msgstr "prova"
+
+#. /item/test
+#: File: strings.xml
+#: ID: dfbb07e029b8f90afe16df3dbaf45f31
+msgid "<p>&lt;foo/&gt;</p>"
+msgstr "<p>&lt;nuovo/&gt;</p>"
+
+#. /item/test
+#: File: strings.xml
+#: ID: ba1635ce734ccfcb4eb3e41dcac46620
+msgid "<foo/>"
+msgstr "<foo/>"
+
+#. /item/linknames/activation
+#: File: strings.xml
+#: ID: 7235172da113bf7d254a0797cb983db9
+msgid "Buy Now"
+msgstr "Acquista adesso"
+
+#. /item/linknames/homepage
+#: File: strings.xml
+#: ID: 3c2e2bd05e342a28845dc2d60a01fd90
+msgid "Gadget Website"
+msgstr ""
+
+#. /item/linknames/support
+#: File: strings.xml
+#: ID: 69420d1c485befa6a92df45c43d0aa28
+msgid "Gadget Support"
+msgstr ""

--- a/t/data/engine/apply_xslt/06/resources/strings.xml
+++ b/t/data/engine/apply_xslt/06/resources/strings.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- This is a comment-->
+<item type="hardware">
+    <id>Gadget</id>
+    <org>ACME Corp.</org>
+    <name>Gadget<!-- test --></name>
+    <categories>
+        <category>hardware</category>
+    </categories>
+    <added></added>
+    <langs>en,fr,ja</langs>
+    <shortdesc>Gadget from ACME</shortdesc>
+    <longdesc><![CDATA[<p>Gadget from ACME can foo and bar.</p><p>Foo and bar without baz!</p>]]></longdesc>
+    <test><![CDATA[<p>&lt;foo/&gt;</p>]]></test>
+    <test>&lt;foo/&gt;</test>
+    <smallimg>http:/example.com/gadget-small.png</smallimg>
+    <largeimg>http:/example.com/gadget-large.png</largeimg>
+    <linknames>
+	   <activation>Buy Now</activation>
+	   <blog>Blog Post</blog>
+	   <homepage>Gadget Website</homepage>
+	   <support>Gadget Support</support>
+    </linknames>
+    <links>
+        <en>
+            <activation><![CDATA[ http://acme.com/products/gadget/shop ]]></activation>
+            <blog>http://blog.acme.com/tag/gadget/</blog>
+        </en>
+    </links>
+</item>

--- a/t/data/engine/apply_xslt/06/translate.serge
+++ b/t/data/engine/apply_xslt/06/translate.serge
@@ -1,0 +1,53 @@
+jobs
+{
+    {
+        @inherit                                 ../../common.serge#job_template
+        source_match                             \.xml$
+
+        parser
+        {
+            plugin                               parse_xml
+
+            data
+            {
+                node_match                       ^/item/(name|shortdesc|longdesc|test|activationdesc)$
+                                                 ^/item/linknames/
+
+                node_exclude                     ^/item/[\w]+desc$
+                                                 blog
+            }
+        }
+
+        callback_plugins
+        {
+            :test_language
+            {
+                plugin                           test_language
+
+                data
+                {
+                    save_translations            YES
+
+                    translations
+                    {
+                        `Gadget`                `Dispositivo`
+                        `test`                  `prova`
+                        `<p>&lt;foo/&gt;</p>`   `<p>&lt;nuovo/&gt;</p>`
+                        `<foo/>`                `<foo/>`
+                        `Buy Now`               `Acquista adesso`
+                    }
+                }
+            }
+
+            {
+                plugin                           apply_xslt
+                phase                            before_save_localized_file
+
+                data
+                {
+                    apply                        ./copy.xslt
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
To be used instead of replace_strings for xml processing. 

Also, this would be the basis of xliff serializer customization, as xliff providers handle things differently. Needs https://github.com/evernote/serge/pull/74 (after_serialize_ts_file, before_deserialize_ts_file phases).