### PR TITLE
Added Perl 5.26 and 5.28 to Travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,8 @@ script:
 after_success:
   - cover -report codecov
 perl:
+  - "5.28"
+  - "5.26"
   - "5.24"
   - "5.22"
   - "5.18"


### PR DESCRIPTION
perl 5.26 was released in 2017 while 5.28 in 2018