### PR TITLE
Change Pootle plugin mame so that it does not mention .po

### DIFF
--- a/lib/Serge/Sync/Plugin/TranslationService/pootle.pm
+++ b/lib/Serge/Sync/Plugin/TranslationService/pootle.pm
@@ -6,7 +6,7 @@ use strict;
 use Serge::Util qw(subst_macros);
 
 sub name {
-    return 'Pootle translation server (http://pootle.translatehouse.org/) .po synchronization plugin';
+    return 'Pootle translation server (http://pootle.translatehouse.org/) synchronization plugin';
 }
 
 sub init {


### PR DESCRIPTION
Pootle has xliff support as well, and with the addition of the xliff serializer, so having .po in the name is misleading. This fixes #105.