### PR TITLE
Fix relative paths resolving

### DIFF
--- a/lib/Serge/Command/import.pm
+++ b/lib/Serge/Command/import.pm
@@ -52,6 +52,7 @@ sub run {
         print "\n*** $_ ***\n\n";
 
         my $config = Serge::Config->new($_);
+        $config->chdir();
         my $processor = Serge::Engine::Processor->new($importer, $config);
         $processor->run();
 


### PR DESCRIPTION
When serge import command run with specifying config folder relative paths are resolved relative to current working directory instead of config file location.