### PR TITLE
Omit 'approved' in XLIFF on untranslated/fuzzy-matched strings (#136)

### DIFF
--- a/lib/Serge/Engine/Plugin/serialize_xliff.pm
+++ b/lib/Serge/Engine/Plugin/serialize_xliff.pm
@@ -54,7 +54,7 @@ sub serialize {
 
         $unit_element->set_att('xml:space' => 'preserve');
 
-        if ($source_lang ne $lang) {
+        if ($source_lang ne $lang && $unit->{target} ne '') {
             my $approved = $unit->{fuzzy} ? "no" : "yes";
 
             $unit_element->set_att(approved => $approved);

--- a/t/data/engine/apply_xslt/06-xliff-context-to-resname/reference-output/po/de/messages.json.xliff
+++ b/t/data/engine/apply_xslt/06-xliff-context-to-resname/reference-output/po/de/messages.json.xliff
@@ -2,17 +2,17 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
   <file datatype="x-unknown" original="messages.json" source-language="en" target-language="de">
     <body>
-      <trans-unit resname="string1" approved="yes" id="37881f5ca702bb268877e4edb0edc83d" xml:space="preserve">
+      <trans-unit resname="string1" id="37881f5ca702bb268877e4edb0edc83d" xml:space="preserve">
         <source xml:lang="en">Value 1</source>
         <target state="new" xml:lang="de"/>
         <note from="developer">Description 1</note>
       </trans-unit>
-      <trans-unit resname="string2" approved="yes" id="7d8ec73df55728a29c38a9f7741aefa6" xml:space="preserve">
+      <trans-unit resname="string2" id="7d8ec73df55728a29c38a9f7741aefa6" xml:space="preserve">
         <source xml:lang="en">Value 2</source>
         <target state="new" xml:lang="de"/>
         <note from="developer">Description 2</note>
       </trans-unit>
-      <trans-unit resname="string3" approved="yes" id="8d1512246f4e8f44726fbe2f99e7e8b8" xml:space="preserve">
+      <trans-unit resname="string3" id="8d1512246f4e8f44726fbe2f99e7e8b8" xml:space="preserve">
         <source xml:lang="en">Value 3</source>
         <target state="new" xml:lang="de"/>
       </trans-unit>

--- a/t/data/engine/apply_xslt/07-xliff-firstnote-to-resname/reference-output/database/properties
+++ b/t/data/engine/apply_xslt/07-xliff-firstnote-to-resname/reference-output/database/properties
@@ -6,11 +6,11 @@ properties
     3     4 items:1 1,2,3,4
     4     5 ts:1:de:count 4
     5     6 usn:1:de 9
-    6     7 ts:1:de 7979d8d75a15c8a1c5b253d98a6d01c6
+    6     7 ts:1:de 7a574e1572d7767eb3a4e3b7233fe539
     7     8 target:1:test_job:de a420575ec883623effd5f799e97229df
     8     9 target:mtime:1:test_job:de 12345678
     9     10 source:1:test_job:de 023530fa5cff5156dd01af01cd4cdc15
-    10    11 source:ts:1:test_job:de 7979d8d75a15c8a1c5b253d98a6d01c6
+    10    11 source:ts:1:test_job:de 7a574e1572d7767eb3a4e3b7233fe539
     11    12 job-hash:test_namespace:test_job
           bfe1e1eb928aa02b19de04fb3c32c398
     12    13 job-plugin:test_namespace:test_job parse_properties.

--- a/t/data/engine/apply_xslt/07-xliff-firstnote-to-resname/reference-output/po/de/StripesResources.properties.xliff
+++ b/t/data/engine/apply_xslt/07-xliff-firstnote-to-resname/reference-output/po/de/StripesResources.properties.xliff
@@ -2,7 +2,7 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
   <file datatype="x-unknown" original="StripesResources.properties" source-language="en" target-language="de">
     <body>
-      <trans-unit resname="foo" approved="yes" id="f1bab58f0303667b6cf6a5f24e05a88f" xml:space="preserve">
+      <trans-unit resname="foo" id="f1bab58f0303667b6cf6a5f24e05a88f" xml:space="preserve">
         <source xml:lang="en">first</source>
         <target state="new" xml:lang="de"/>
         <context-group name="serge" purpose="x-serge">
@@ -11,7 +11,7 @@
         </context-group>
         <note from="developer">1st</note>
       </trans-unit>
-      <trans-unit resname="foo2" approved="yes" id="1e37e373c0b0a4981c9943b6cec34a79" xml:space="preserve">
+      <trans-unit resname="foo2" id="1e37e373c0b0a4981c9943b6cec34a79" xml:space="preserve">
         <source xml:lang="en">second</source>
         <target state="new" xml:lang="de"/>
         <context-group name="serge" purpose="x-serge">
@@ -19,7 +19,7 @@
           <context context-type="x-serge-file-id">1</context>
         </context-group>
       </trans-unit>
-      <trans-unit resname="foo3" approved="yes" id="6adcf47f5d5e138188187f3260dd2b99" xml:space="preserve">
+      <trans-unit resname="foo3" id="6adcf47f5d5e138188187f3260dd2b99" xml:space="preserve">
         <source xml:lang="en">third</source>
         <target state="new" xml:lang="de"/>
         <context-group name="serge" purpose="x-serge">
@@ -29,7 +29,7 @@
         <note from="developer">3rd line 1</note>
         <note from="developer">3rd line 2</note>
       </trans-unit>
-      <trans-unit resname="foo4" approved="yes" id="973ff8ad7d1514cba9d5f821e2d99224" xml:space="preserve">
+      <trans-unit resname="foo4" id="973ff8ad7d1514cba9d5f821e2d99224" xml:space="preserve">
         <source xml:lang="en">fourth</source>
         <target state="new" xml:lang="de"/>
         <context-group name="serge" purpose="x-serge">

--- a/t/data/engine/serialize_xliff/00/reference-output/database/properties
+++ b/t/data/engine/serialize_xliff/00/reference-output/database/properties
@@ -6,20 +6,20 @@ properties
     3     4 items:1 1,2,3
     4     5 ts:1:test:count 3
     5     6 usn:1:test 8
-    6     7 ts:1:test fcbf3c0825dc236c425c3e0106f7ddb3
+    6     7 ts:1:test e17c80cb5529069d2bc1666ced4f6163
     7     8 ts:1:zh-cn:count 3
     8     9 usn:1:zh-cn 7
-    9     10 ts:1:zh-cn a09d78f6ba3662a726b931eacff0cc72
+    9     10 ts:1:zh-cn c9e4a7a3f57c76fd5a2e82ab831c5cf5
     10    11 target:1:test_job:test 27d3de8a47eb32e419366577e4100eb0
     11    12 target:mtime:1:test_job:test 12345678
     12    13 source:1:test_job:test c161ca36eeac229f00480ec3f3bbae20
     13    14 source:ts:1:test_job:test
-          fcbf3c0825dc236c425c3e0106f7ddb3
+          e17c80cb5529069d2bc1666ced4f6163
     14    15 target:1:test_job:zh-cn 12897f1555daf2bf1fac0ef3c4714a7c
     15    16 target:mtime:1:test_job:zh-cn 12345678
     16    17 source:1:test_job:zh-cn c161ca36eeac229f00480ec3f3bbae20
     17    18 source:ts:1:test_job:zh-cn
-          a09d78f6ba3662a726b931eacff0cc72
+          c9e4a7a3f57c76fd5a2e82ab831c5cf5
     18    19 job-hash:test_namespace:test_job
           ceba159f21cfeb9eb1635aba8c5a2623
     19    20 job-plugin:test_namespace:test_job parse_chrome_json.

--- a/t/data/engine/serialize_xliff/00/reference-output/po/test/messages.json.xliff
+++ b/t/data/engine/serialize_xliff/00/reference-output/po/test/messages.json.xliff
@@ -2,7 +2,7 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
     <file datatype="x-unknown" original="messages.json" source-language="en" target-language="test">
         <body>
-            <trans-unit approved="yes" id="37881f5ca702bb268877e4edb0edc83d" xml:space="preserve">
+            <trans-unit id="37881f5ca702bb268877e4edb0edc83d" xml:space="preserve">
                 <source xml:lang="en">Value 1</source>
                 <target state="new" xml:lang="test" />
                 <note from="developer">Description 1</note>
@@ -22,7 +22,7 @@
                     <context context-type="x-serge-context">string2</context>
                 </context-group>
             </trans-unit>
-            <trans-unit approved="yes" id="8d1512246f4e8f44726fbe2f99e7e8b8" xml:space="preserve">
+            <trans-unit id="8d1512246f4e8f44726fbe2f99e7e8b8" xml:space="preserve">
                 <source xml:lang="en">Value 3</source>
                 <target state="new" xml:lang="test" />
                 <note from="developer">Description 3</note>

--- a/t/data/engine/serialize_xliff/00/reference-output/po/zh_CN/messages.json.xliff
+++ b/t/data/engine/serialize_xliff/00/reference-output/po/zh_CN/messages.json.xliff
@@ -2,7 +2,7 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
     <file datatype="x-unknown" original="messages.json" source-language="en" target-language="zh-CN">
         <body>
-            <trans-unit approved="yes" id="37881f5ca702bb268877e4edb0edc83d" xml:space="preserve">
+            <trans-unit id="37881f5ca702bb268877e4edb0edc83d" xml:space="preserve">
                 <source xml:lang="en">Value 1</source>
                 <target state="new" xml:lang="zh-CN" />
                 <note from="developer">Description 1</note>
@@ -12,7 +12,7 @@
                     <context context-type="x-serge-context">string1</context>
                 </context-group>
             </trans-unit>
-            <trans-unit approved="yes" id="7d8ec73df55728a29c38a9f7741aefa6" xml:space="preserve">
+            <trans-unit id="7d8ec73df55728a29c38a9f7741aefa6" xml:space="preserve">
                 <source xml:lang="en">Value 2</source>
                 <target state="new" xml:lang="zh-CN" />
                 <note from="developer">Description 2</note>
@@ -22,7 +22,7 @@
                     <context context-type="x-serge-context">string2</context>
                 </context-group>
             </trans-unit>
-            <trans-unit approved="yes" id="8d1512246f4e8f44726fbe2f99e7e8b8" xml:space="preserve">
+            <trans-unit id="8d1512246f4e8f44726fbe2f99e7e8b8" xml:space="preserve">
                 <source xml:lang="en">Value 3</source>
                 <target state="new" xml:lang="zh-CN" />
                 <note from="developer">Description 3</note>

--- a/t/data/engine/serialize_xliff/02-deserialize-comment/reference-output/database/properties
+++ b/t/data/engine/serialize_xliff/02-deserialize-comment/reference-output/database/properties
@@ -6,11 +6,11 @@ properties
     3     4 items:1 1,2,3,4
     4     5 ts:1:de:count 4
     5     6 usn:1:de 12
-    6     7 ts:1:de 44a51a0f5a864efa1751ee35f28a0046
+    6     7 ts:1:de c4460498475c436b83713e587dac013b
     7     8 target:1:test_job:de ad54639450ddb8019e5f86ac6b31c658
     8     9 target:mtime:1:test_job:de 12345678
     9     10 source:1:test_job:de 023530fa5cff5156dd01af01cd4cdc15
-    10    11 source:ts:1:test_job:de 44a51a0f5a864efa1751ee35f28a0046
+    10    11 source:ts:1:test_job:de c4460498475c436b83713e587dac013b
     11    12 job-hash:test_namespace:test_job
           e1d98a6e6b6ca2cd09cf507f52c534df
     12    13 job-plugin:test_namespace:test_job parse_properties.

--- a/t/data/engine/serialize_xliff/02-deserialize-comment/reference-output/po/de/StripesResources.properties.xliff
+++ b/t/data/engine/serialize_xliff/02-deserialize-comment/reference-output/po/de/StripesResources.properties.xliff
@@ -32,7 +32,7 @@
                     <context context-type="x-serge-file-id">1</context>
                 </context-group>
             </trans-unit>
-            <trans-unit approved="yes" id="973ff8ad7d1514cba9d5f821e2d99224" xml:space="preserve">
+            <trans-unit id="973ff8ad7d1514cba9d5f821e2d99224" xml:space="preserve">
                 <source xml:lang="en">fourth</source>
                 <target state="new" xml:lang="de" />
                 <note from="developer">foo4</note>

--- a/t/data/engine/serialize_xliff/03-deserialize-context/reference-output/database/properties
+++ b/t/data/engine/serialize_xliff/03-deserialize-context/reference-output/database/properties
@@ -6,11 +6,11 @@ properties
     3     4 items:1 1,2,3,4
     4     5 ts:1:de:count 4
     5     6 usn:1:de 12
-    6     7 ts:1:de a2d315bf4319776324bbc25d9c2be1b6
+    6     7 ts:1:de 4245d6f819ba43a8247eef2c78e81951
     7     8 target:1:test_job:de 96f5d9ffcd4d81e3e1b0c412b5e4b399
     8     9 target:mtime:1:test_job:de 12345678
     9     10 source:1:test_job:de 215a7140a8fb7c4b02d4afd9dec5bc2d
-    10    11 source:ts:1:test_job:de a2d315bf4319776324bbc25d9c2be1b6
+    10    11 source:ts:1:test_job:de 4245d6f819ba43a8247eef2c78e81951
     11    12 job-hash:test_namespace:test_job
           e1d98a6e6b6ca2cd09cf507f52c534df
     12    13 job-plugin:test_namespace:test_job parse_properties.

--- a/t/data/engine/serialize_xliff/03-deserialize-context/reference-output/po/de/StripesResources.properties.xliff
+++ b/t/data/engine/serialize_xliff/03-deserialize-context/reference-output/po/de/StripesResources.properties.xliff
@@ -23,7 +23,7 @@
                     <context context-type="x-serge-file-id">1</context>
                 </context-group>
             </trans-unit>
-            <trans-unit approved="yes" id="b2ec9e2f7eb5151d3db4591441d4e0d1" xml:space="preserve">
+            <trans-unit id="b2ec9e2f7eb5151d3db4591441d4e0d1" xml:space="preserve">
                 <source xml:lang="en">bar3</source>
                 <target state="new" xml:lang="de" />
                 <note from="developer">foo3</note>


### PR DESCRIPTION
See #136 for an in-depth description of the issue.

Now Serge will check if the translation is complete before we include an `approved` attribute on `<trans-unit>` elements during XLIFF serialization. It will still be set to "no" if the translated string was fuzzy-matched from a previous translation. I updated the "golden" test diffs via: `perl t/engine.t --init apply_xslt serialize_xliff`. I then verified that the updated XLIFF files matched these new expectations.