### PR TITLE
Restores the ttx generation of the translated text

### DIFF
--- a/bin/tools/export_to_ttx.pl
+++ b/bin/tools/export_to_ttx.pl
@@ -585,8 +585,8 @@ sub ttx_export_callback {
         my $chunks = get_wordcount_chunks($string);
         my $string_ttx = make_final_xml($chunks);
 
-        #my $translation_chunks = get_wordcount_chunks($translation);
-        #my $translation_ttx = make_final_xml($translation_chunks);
+        my $translation_chunks = get_wordcount_chunks($translation);
+        my $translation_ttx = make_final_xml($translation_chunks);
 
         my $string_html = make_final_xml($chunks, 1); # 1:for_html
 
@@ -607,7 +607,7 @@ sub ttx_export_callback {
 
         $$ttxref .= <<__END__;
 <ut Type="standalone" Style="external" RightEdge="angle">$id</ut>$hint_ttx$context_ttx
-<Tu Origin="undefined"><Tuv Lang="EN-US">$string_ttx</Tuv><Tuv Lang="$locale">$string_ttx</Tuv></Tu>
+<Tu Origin="undefined"><Tuv Lang="EN-US">$string_ttx</Tuv><Tuv Lang="$locale">$translation_ttx</Tuv></Tu>
 __END__
 
         $$htmlref .= <<__END__;


### PR DESCRIPTION
Restores the ttx generation of the translated text in the TTX file. Not clear why the code was commented, but previous to this PR the TTX (and HTML) is showing the same value in EN and the target lang. This PR doesn't cover the fix for HTML files.